### PR TITLE
Complete implementation of beer status field (Issue #2)

### DIFF
--- a/client/src/pages/BeerBrowser.tsx
+++ b/client/src/pages/BeerBrowser.tsx
@@ -39,6 +39,9 @@ export default function BeerBrowser() {
   const filteredBeers = useMemo(() => {
     let result = beers;
 
+    // Filter out beers with status "out"
+    result = result.filter(beer => beer.status !== "out");
+
     // Filter by menu category
     if (
       selectedMenuCategory &&
@@ -272,13 +275,29 @@ export default function BeerBrowser() {
                     )}
 
                     <div className="space-y-2">
-                      <div className="flex items-center gap-2 text-sm">
+                      <div className="flex items-center gap-2 text-sm flex-wrap">
                         <Badge
                           variant="outline"
                           className="bg-amber-50 text-amber-900 border-amber-300"
                         >
                           {getStyleName(beer.styleId)}
                         </Badge>
+                        {beer.status === "on_tap" && (
+                          <Badge
+                            variant="outline"
+                            className="bg-blue-50 text-blue-900 border-blue-300"
+                          >
+                            On Tap
+                          </Badge>
+                        )}
+                        {beer.status === "bottle_can" && (
+                          <Badge
+                            variant="outline"
+                            className="bg-green-50 text-green-900 border-green-300"
+                          >
+                            Bottle/Can
+                          </Badge>
+                        )}
                       </div>
 
                       <div className="grid grid-cols-2 gap-3 pt-2 border-t border-amber-100">

--- a/client/src/pages/BeerPage.tsx
+++ b/client/src/pages/BeerPage.tsx
@@ -18,6 +18,7 @@ export default function BeerPage() {
     styleId: "",
     abv: "",
     ibu: "",
+    status: "out" as "on_tap" | "bottle_can" | "out",
   });
 
   const { data: beers, isLoading, refetch } = trpc.beer.list.useQuery();
@@ -43,6 +44,7 @@ export default function BeerPage() {
           styleId,
           abv: formData.abv || undefined,
           ibu,
+          status: formData.status,
         });
         toast.success("Beer updated successfully");
       } else {
@@ -53,10 +55,11 @@ export default function BeerPage() {
           styleId,
           abv: formData.abv || undefined,
           ibu,
+          status: formData.status,
         });
         toast.success("Beer created successfully");
       }
-      setFormData({ name: "", description: "", breweryId: "", styleId: "", abv: "", ibu: "" });
+      setFormData({ name: "", description: "", breweryId: "", styleId: "", abv: "", ibu: "", status: "out" });
       setEditingId(null);
       setOpen(false);
       refetch();
@@ -73,6 +76,7 @@ export default function BeerPage() {
       styleId: beer.styleId?.toString() || "",
       abv: beer.abv || "",
       ibu: beer.ibu?.toString() || "",
+      status: beer.status || "out",
     });
     setEditingId(beer.beerId);
     setOpen(true);
@@ -94,7 +98,7 @@ export default function BeerPage() {
         <h2 className="text-xl font-bold">Beers</h2>
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
-            <Button onClick={() => { setEditingId(null); setFormData({ name: "", description: "", breweryId: "", styleId: "", abv: "", ibu: "" }); }}>
+            <Button onClick={() => { setEditingId(null); setFormData({ name: "", description: "", breweryId: "", styleId: "", abv: "", ibu: "", status: "out" }); }}>
               <Plus className="w-4 h-4 mr-2" />
               Add Beer
             </Button>
@@ -172,6 +176,18 @@ export default function BeerPage() {
                   />
                 </div>
               </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Status</label>
+                <select
+                  value={formData.status}
+                  onChange={(e) => setFormData({ ...formData, status: e.target.value as "on_tap" | "bottle_can" | "out" })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                >
+                  <option value="on_tap">On Tap</option>
+                  <option value="bottle_can">Bottle/Can</option>
+                  <option value="out">Out</option>
+                </select>
+              </div>
               <Button type="submit" className="w-full">
                 {editingId ? "Update" : "Create"} Beer
               </Button>
@@ -200,6 +216,9 @@ export default function BeerPage() {
                   )}
                   {beer.abv && <p>ABV: {beer.abv}%</p>}
                   {beer.ibu && <p>IBU: {beer.ibu}</p>}
+                  <p>Status: <span className="font-medium">
+                    {beer.status === "on_tap" ? "On Tap" : beer.status === "bottle_can" ? "Bottle/Can" : "Out"}
+                  </span></p>
                 </div>
                 <div className="flex gap-2">
                   <Button

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -95,6 +95,7 @@ export const appRouter = router({
         styleId: z.number().optional(),
         abv: z.string().optional(),
         ibu: z.number().optional(),
+        status: z.enum(["on_tap", "bottle_can", "out"]).optional(),
       }))
       .mutation(({ input }) => db.createBeer(input)),
     update: publicProcedure
@@ -106,6 +107,7 @@ export const appRouter = router({
         styleId: z.number().optional(),
         abv: z.string().optional(),
         ibu: z.number().optional(),
+        status: z.enum(["on_tap", "bottle_can", "out"]).optional(),
       }))
       .mutation(({ input }) => {
         const { id, ...data } = input;


### PR DESCRIPTION
This PR completes the implementation of issue #2 by adding the beer status field functionality throughout the application.

## Changes Made

### Backend (Server)
- Updated `server/routers.ts` to include the `status` field in both `beer.create` and `beer.update` API endpoints
- Added Zod validation for status enum values: `on_tap`, `bottle_can`, `out`

### Frontend - Beer Management (BeerPage.tsx)
- Added `status` field to the form state with default value of `out`
- Added a status dropdown selector in the beer creation/editing form
- Updated form submission handlers to include status in both create and update operations
- Added status display in the beer cards showing the current status

### Frontend - Beer Browser (BeerBrowser.tsx)
- Implemented filtering to exclude beers with status `out` from the browser view
- Added visual status badges for `on_tap` (blue) and `bottle_can` (green) beers
- Badges are displayed alongside the style badge for easy identification

## Acceptance Criteria Met
- ✅ While managing the catalog, the beer page has a status field for editing beers
- ✅ While managing the catalog, the beer page has a status field for adding beers
- ✅ In the browser view, beers that are "Out" are excluded

## Testing Recommendations
1. Create a new beer with different status values
2. Edit an existing beer and change its status
3. Verify that beers with status "Out" do not appear in the browser view
4. Verify that beers with "On Tap" and "Bottle/Can" status display appropriate badges in the browser view

Closes #2