### PR TITLE
Move beer status filtering to database query (Issue #2)

### DIFF
--- a/client/src/pages/BeerBrowser.tsx
+++ b/client/src/pages/BeerBrowser.tsx
@@ -25,7 +25,7 @@ export default function BeerBrowser() {
 
   // Fetch all data
   const { data: beers = [], isLoading: beersLoading } =
-    trpc.beer.list.useQuery();
+    trpc.beer.listAvailable.useQuery();
   const { data: styles = [] } = trpc.style.list.useQuery();
   const { data: breweries = [] } = trpc.brewery.list.useQuery();
   const { data: menuCategories = [] } = trpc.menuCategory.list.useQuery();
@@ -38,9 +38,6 @@ export default function BeerBrowser() {
   // Filter beers based on selections
   const filteredBeers = useMemo(() => {
     let result = beers;
-
-    // Filter out beers with status "out"
-    result = result.filter(beer => beer.status !== "out");
 
     // Filter by menu category
     if (

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,4 +1,4 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, ne } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import {
   InsertUser,
@@ -225,6 +225,12 @@ export async function getAllBeers() {
   const db = await getDb();
   if (!db) return [];
   return db.select().from(beer);
+}
+
+export async function getAllAvailableBeers() {
+  const db = await getDb();
+  if (!db) return [];
+  return db.select().from(beer).where(ne(beer.status, "out"));
 }
 
 export async function getBeerById(id: number) {

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -84,6 +84,7 @@ export const appRouter = router({
 
   beer: router({
     list: publicProcedure.query(() => db.getAllBeers()),
+    listAvailable: publicProcedure.query(() => db.getAllAvailableBeers()),
     getById: publicProcedure.input(z.object({ id: z.number() })).query(({ input }) =>
       db.getBeerById(input.id)
     ),


### PR DESCRIPTION
This PR optimizes the beer status filtering by moving it from the client-side to the database query level.

## Problem

The previous implementation fetched all beers from the database and filtered out "out" status beers on the client side. This approach:
- Transferred unnecessary data from server to client
- Performed filtering on the client side
- Was inefficient, especially for large datasets

## Solution

This PR moves the filtering to the database level by:

### Backend Changes

**`server/db.ts`**
- Added `getAllAvailableBeers()` function that filters beers at the database level
- Uses Drizzle ORM's `ne()` operator to exclude beers with status "out"
- Imported `ne` operator from drizzle-orm

**`server/routers.ts`**
- Added new `beer.listAvailable` query endpoint
- Returns only available beers (status != "out")

### Frontend Changes

**`client/src/pages/BeerBrowser.tsx`**
- Changed from `trpc.beer.list.useQuery()` to `trpc.beer.listAvailable.useQuery()`
- Removed client-side status filtering logic from `useMemo`
- Simplified the filtering logic

## Benefits

✅ **Reduced data transfer** - Only available beers are sent from server to client  
✅ **Improved performance** - Database-level filtering is more efficient  
✅ **Better scalability** - More efficient for large datasets  
✅ **Cleaner code** - Separation of concerns between data fetching and UI filtering

## Testing

The browser view should continue to work exactly as before, showing only beers with "on_tap" or "bottle_can" status, but now with improved performance.

Related to #2