### PR TITLE
Fix filter badge X button and split badges to individual

### DIFF
--- a/client/src/pages/BeerBrowser.tsx
+++ b/client/src/pages/BeerBrowser.tsx
@@ -207,39 +207,54 @@ export default function BeerBrowser() {
           {/* Active Filters Display - Desktop and Mobile */}
           {hasActiveFilters && (
             <div className="mt-4 flex items-center gap-2 flex-wrap">
-              {selectedMenuCategories.length > 0 && (
-                <Badge variant="secondary" className="cursor-pointer">
-                  Categories: {selectedMenuCategories.map(id => 
-                    menuCategories.find(c => c.menu_cat_id === parseInt(id))?.name
-                  ).join(", ")}
-                  <X 
-                    className="w-3 h-3 ml-1" 
-                    onClick={() => setSelectedMenuCategories([])}
-                  />
-                </Badge>
-              )}
-              {selectedStyles.length > 0 && (
-                <Badge variant="secondary" className="cursor-pointer">
-                  Styles: {selectedStyles.map(id =>
-                    styles.find(s => s.styleId === parseInt(id))?.name
-                  ).join(", ")}
-                  <X 
-                    className="w-3 h-3 ml-1" 
-                    onClick={() => setSelectedStyles([])}
-                  />
-                </Badge>
-              )}
-              {selectedBreweries.length > 0 && (
-                <Badge variant="secondary" className="cursor-pointer">
-                  Breweries: {selectedBreweries.map(id =>
-                    breweries.find(b => b.breweryId === parseInt(id))?.name
-                  ).join(", ")}
-                  <X 
-                    className="w-3 h-3 ml-1" 
-                    onClick={() => setSelectedBreweries([])}
-                  />
-                </Badge>
-              )}
+              {selectedMenuCategories.map(id => {
+                const category = menuCategories.find(c => c.menu_cat_id === parseInt(id));
+                return category ? (
+                  <Badge
+                    key={`cat-${id}`}
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() => setSelectedMenuCategories(
+                      selectedMenuCategories.filter(catId => catId !== id)
+                    )}
+                  >
+                    {category.name}
+                    <X className="w-3 h-3 ml-1" />
+                  </Badge>
+                ) : null;
+              })}
+              {selectedStyles.map(id => {
+                const style = styles.find(s => s.styleId === parseInt(id));
+                return style ? (
+                  <Badge
+                    key={`style-${id}`}
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() => setSelectedStyles(
+                      selectedStyles.filter(styleId => styleId !== id)
+                    )}
+                  >
+                    {style.name}
+                    <X className="w-3 h-3 ml-1" />
+                  </Badge>
+                ) : null;
+              })}
+              {selectedBreweries.map(id => {
+                const brewery = breweries.find(b => b.breweryId === parseInt(id));
+                return brewery ? (
+                  <Badge
+                    key={`brewery-${id}`}
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() => setSelectedBreweries(
+                      selectedBreweries.filter(breweryId => breweryId !== id)
+                    )}
+                  >
+                    {brewery.name}
+                    <X className="w-3 h-3 ml-1" />
+                  </Badge>
+                ) : null;
+              })}
               <Button
                 variant="ghost"
                 size="sm"


### PR DESCRIPTION
# Fix filter badge X button and split badges to individual

Fixes #35

## Summary

This PR fixes the broken X button on filter badges and splits the grouped badges back to individual badges as requested in issue #35.

## Problem

After implementing PR #34 (multiple selection), the filter badges were changed to grouped format:
- "Categories: Hoppy, Malty"
- "Styles: IPA, Stout, Lager"
- "Breweries: Brewery A, Brewery B"

This caused two issues:
1. The X button didn't work properly (it cleared the entire filter type instead of individual selections)
2. Users couldn't remove individual selections easily

## Solution

Changed the badge display from grouped to individual:
- Before: One badge per filter type showing all selections
- After: One badge per individual selection

Each badge now has a working X button that removes only that specific selection from the filter array.

## Changes

### Badge Display

**Before (Grouped):**
```
[Categories: Hoppy, Malty ×] [Styles: IPA, Stout ×] [Clear All]
```

**After (Individual):**
```
[Hoppy ×] [Malty ×] [IPA ×] [Stout ×] [Clear All]
```

### Click Handler

Fixed the X button click handler to properly remove individual items:

```typescript
// Before (cleared entire filter type)
onClick={() => setSelectedMenuCategories([])}

// After (removes only the clicked item)
onClick={() => setSelectedMenuCategories(
  selectedMenuCategories.filter(catId => catId !== id)
)}
```

### Implementation Details

- Map through each selected item to create individual badges
- Each badge has its own click handler that filters out only that item
- Added proper React keys for each badge
- Maintained the "Clear All" button for removing all filters at once

## User Experience

### Individual Removal
Users can now click the X on any badge to remove just that selection while keeping other filters active.

### Clear All
The "Clear All" button remains available to remove all filters at once.

### Visual Clarity
Individual badges make it immediately clear which specific items are selected, rather than having to read a comma-separated list.

## Testing

Tested scenarios:
- ✅ Click X on individual badge removes only that selection
- ✅ Other selections remain active
- ✅ Filter results update correctly after removal
- ✅ "Clear All" button still works
- ✅ Works on both desktop and mobile views
- ✅ No console errors

## Technical Details

### Code Changes
- Modified the active filters display section in `BeerBrowser.tsx`
- Changed from single grouped badge per filter type to mapped individual badges
- Updated click handlers to use array filter instead of clearing entire array
- Added unique keys for each badge using filter type and ID

### Backward Compatibility
- No breaking changes
- No database changes
- No API changes
- Works with existing filter state management

## Before/After Comparison

**Before (Broken):**
- Grouped badges: "Styles: IPA, Stout, Lager"
- Clicking X cleared all styles at once
- Hard to remove individual selections

**After (Fixed):**
- Individual badges: "IPA", "Stout", "Lager"
- Clicking X removes only that specific style
- Easy to manage selections individually
