### PR TITLE
Add searchable brewery filter in beer management

### DIFF
--- a/client/src/components/ui/searchable-select.tsx
+++ b/client/src/components/ui/searchable-select.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+export interface SearchableSelectOption {
+  label: string;
+  value: string;
+}
+
+interface SearchableSelectProps {
+  options: SearchableSelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  emptyText?: string;
+  searchPlaceholder?: string;
+  className?: string;
+}
+
+export function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder = "Select an option...",
+  emptyText = "No results found.",
+  searchPlaceholder = "Search...",
+  className,
+}: SearchableSelectProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const selectedOption = options.find((option) => option.value === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn("w-full justify-between", className)}
+        >
+          <span className="truncate">
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-full p-0" align="start">
+        <Command
+          filter={(value, search) => {
+            // Custom filter for case-insensitive substring matching
+            const option = options.find((opt) => opt.value === value);
+            if (!option) return 0;
+            
+            const label = option.label.toLowerCase();
+            const searchTerm = search.toLowerCase();
+            
+            // Match if search term appears anywhere in the label
+            return label.includes(searchTerm) ? 1 : 0;
+          }}
+        >
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  value={option.value}
+                  onSelect={(currentValue) => {
+                    onChange(currentValue === value ? "" : currentValue);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === option.value ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  {option.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/client/src/pages/BeerPage.tsx
+++ b/client/src/pages/BeerPage.tsx
@@ -7,6 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Trash2, Edit2 } from "lucide-react";
 import { toast } from "sonner";
+import { SearchableSelect, SearchableSelectOption } from "@/components/ui/searchable-select";
 
 export default function BeerPage() {
   const [open, setOpen] = useState(false);
@@ -127,18 +128,19 @@ export default function BeerPage() {
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1">Brewery</label>
-                <select
+                <SearchableSelect
+                  options={
+                    breweries?.map((brewery) => ({
+                      label: brewery.name,
+                      value: brewery.breweryId.toString(),
+                    })) || []
+                  }
                   value={formData.breweryId}
-                  onChange={(e) => setFormData({ ...formData, breweryId: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                >
-                  <option value="">Select a brewery</option>
-                  {breweries?.map((brewery) => (
-                    <option key={brewery.breweryId} value={brewery.breweryId}>
-                      {brewery.name}
-                    </option>
-                  ))}
-                </select>
+                  onChange={(value) => setFormData({ ...formData, breweryId: value })}
+                  placeholder="Select a brewery"
+                  emptyText="No breweries found"
+                  searchPlaceholder="Search breweries..."
+                />
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1">Style</label>


### PR DESCRIPTION
# Add searchable brewery filter in beer management

Fixes #31

## Summary

This PR adds a searchable/filterable brewery selector in the Manage view when adding or editing beers. Users can now type to filter brewery options, with case-insensitive substring matching anywhere in the brewery name.

## Changes

### New Component: SearchableSelect

Created a reusable `SearchableSelect` component (`client/src/components/ui/searchable-select.tsx`) that provides:
- Searchable dropdown using shadcn/ui Command component
- Case-insensitive substring matching
- Matches search term anywhere in the option label
- Customizable placeholder, empty state text, and search placeholder
- Clean combobox UI with checkmark for selected item

### Updated BeerPage

Modified the beer add/edit form in `BeerPage.tsx`:
- Replaced standard `<select>` element with `SearchableSelect` component
- Applied to the Brewery field only (as requested)
- Maintained existing placeholder text: "Select a brewery"
- Shows "No breweries found" when search has no matches
- Search placeholder: "Search breweries..."

## User Experience

### Before
- Standard dropdown with no search capability
- Had to scroll through all breweries to find the right one
- No way to filter options

### After
- Click to open searchable dropdown
- Type to filter breweries in real-time
- Case-insensitive matching anywhere in name
- Example: typing "city" matches both "City Brewing Company" and "Love City Brewing"
- Shows "No breweries found" for searches with no matches
- Selected brewery shows with checkmark

## Technical Implementation

### SearchableSelect Component

Built using shadcn/ui components:
- `Command` - Provides search and filtering functionality
- `Popover` - Dropdown container
- `Button` - Trigger button
- Custom filter function for substring matching

### Filter Logic

```typescript
filter={(value, search) => {
  const option = options.find((opt) => opt.value === value);
  if (!option) return 0;
  
  const label = option.label.toLowerCase();
  const searchTerm = search.toLowerCase();
  
  // Match if search term appears anywhere in the label
  return label.includes(searchTerm) ? 1 : 0;
}}
```

### Props Interface

```typescript
interface SearchableSelectProps {
  options: SearchableSelectOption[];
  value: string;
  onChange: (value: string) => void;
  placeholder?: string;
  emptyText?: string;
  searchPlaceholder?: string;
  className?: string;
}
```

## Reusability

The `SearchableSelect` component is designed to be reusable and can be easily applied to:
- Beer Style selector (future enhancement)
- Menu Category selector
- Any other dropdown that would benefit from search functionality

To use it elsewhere:
```typescript
<SearchableSelect
  options={items.map(item => ({ label: item.name, value: item.id.toString() }))}
  value={selectedValue}
  onChange={setSelectedValue}
  placeholder="Select an item"
  emptyText="No items found"
  searchPlaceholder="Search items..."
/>
```

## Testing

Tested scenarios:
- ✅ Open brewery dropdown and type to filter
- ✅ Case-insensitive matching works
- ✅ Substring matching anywhere in name works
- ✅ "No breweries found" shows for non-matching searches
- ✅ Selected brewery displays correctly
- ✅ Clicking outside closes dropdown
- ✅ Selecting brewery updates form state
- ✅ Creating and editing beers works as before

## Examples

**Search: "city"**
- Matches: "City Brewing Company", "Love City Brewing"
- Doesn't match: "Brooklyn Brewery"

**Search: "brew"**
- Matches: "City Brewing Company", "Brooklyn Brewery", "Stone Brewing"
- Doesn't match: "Dogfish Head"

**Search: "xyz"**
- Shows: "No breweries found"

## Backward Compatibility

- No breaking changes
- No database changes
- No API changes
- Existing brewery selection functionality preserved
- Form submission works identically

## Future Enhancements

This component can be easily applied to:
- Beer Style selector
- Menu Category selector
- Any other dropdowns in the application

The reusable design makes it simple to add search functionality wherever needed.
