### PR TITLE
feat(#97): add filter controls UI to BeerPage curator tab

### DIFF
--- a/.agents/plans/completed/beer-page-filter-controls.plan.md
+++ b/.agents/plans/completed/beer-page-filter-controls.plan.md
@@ -1,0 +1,199 @@
+# Plan: BeerPage Filter Controls UI
+
+## Summary
+
+Add filter controls to the curator BeerPage tab so curators can quickly locate beers by text search, menu category, style, and brewery. The backend filter support already exists (`beer.list` accepts `search`, `menuCategoryIds`, `styleIds`, `breweryIds` as of PR #96). This plan wires up the existing `FilterControls` component and updates the `beer.list` query to pass live filter state — all changes are confined to a single file.
+
+## User Story
+
+As a curator  
+I want to filter the beer list by text search, menu category, style, and brewery  
+So that I can quickly locate the specific beer I need to update
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Type | ENHANCEMENT |
+| Complexity | LOW |
+| Systems Affected | Frontend only (`client/src/pages/BeerPage.tsx`) |
+| GitHub Issue | 97 |
+
+---
+
+## Patterns to Follow
+
+### Filter state + debounced search
+```typescript
+// SOURCE: client/src/pages/BeerBrowser.tsx:73-77
+const [selectedMenuCategories, setSelectedMenuCategories] = useState<string[]>([]);
+const [selectedStyles, setSelectedStyles] = useState<string[]>([]);
+const [selectedBreweries, setSelectedBreweries] = useState<string[]>([]);
+
+// Debounce pattern (not in BeerBrowser, but standard React idiom for this codebase):
+const [search, setSearch] = useState("");
+const [debouncedSearch, setDebouncedSearch] = useState("");
+// useEffect with setTimeout/clearTimeout — no external debounce library needed
+```
+
+### FilterControls usage
+```typescript
+// SOURCE: client/src/pages/BeerBrowser.tsx:206-216
+<div className="grid grid-cols-3 gap-4">
+  <FilterControls
+    selectedMenuCategories={selectedMenuCategories}
+    setSelectedMenuCategories={setSelectedMenuCategories}
+    selectedStyles={selectedStyles}
+    setSelectedStyles={setSelectedStyles}
+    selectedBreweries={selectedBreweries}
+    setSelectedBreweries={setSelectedBreweries}
+    menuCategories={menuCategories}
+    styles={styles}
+    breweries={breweries}
+  />
+</div>
+```
+
+### FilterControls expected prop shapes
+```typescript
+// SOURCE: client/src/components/FilterControls.tsx:3-13
+// menuCategories must be Array<{ menu_cat_id: number; name: string }>
+// styles must be Array<{ styleId: number; name: string }>
+// breweries must be Array<{ breweryId: number; name: string }>
+
+// IMPORTANT: trpc.menuCategory.listAvailable returns { menu_cat_id, name, description }
+// (raw SQL snake_case) — matches FilterControls interface directly.
+// trpc.menuCategory.list (Drizzle) returns { menuCatId, name } — would need mapping.
+// Use listAvailable to avoid transformation.
+```
+
+### Passing filters to beer.list query
+```typescript
+// SOURCE: server/routers.ts:182-191
+// beer.list accepts: { search?, menuCategoryIds?, styleIds?, breweryIds? }
+// All optional; pass numeric arrays converted from string state
+const { data: beers } = trpc.beer.list.useQuery({
+  search: debouncedSearch || undefined,
+  menuCategoryIds: selectedMenuCategories.map(id => parseInt(id)),
+  styleIds: selectedStyles.map(id => parseInt(id)),
+  breweryIds: selectedBreweries.map(id => parseInt(id)),
+});
+```
+
+---
+
+## Files to Change
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `client/src/pages/BeerPage.tsx` | UPDATE | Add filter state, debounced search, filter UI, updated query |
+
+---
+
+## Tasks
+
+### Task 1: Add filter state and debounced search
+
+- **File**: `client/src/pages/BeerPage.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add `useEffect` to existing imports (already has `useState`)
+  - Add four state vars after the existing `useState` declarations (around line 14):
+    ```typescript
+    const [search, setSearch] = useState("");
+    const [debouncedSearch, setDebouncedSearch] = useState("");
+    const [selectedMenuCategories, setSelectedMenuCategories] = useState<string[]>([]);
+    const [selectedStyles, setSelectedStyles] = useState<string[]>([]);
+    const [selectedBreweries, setSelectedBreweries] = useState<string[]>([]);
+    ```
+  - Add debounce `useEffect` after the state declarations:
+    ```typescript
+    useEffect(() => {
+      const timer = setTimeout(() => setDebouncedSearch(search), 300);
+      return () => clearTimeout(timer);
+    }, [search]);
+    ```
+- **Mirror**: `client/src/pages/BeerBrowser.tsx:73-77` for state shape
+- **Validate**: `npm run check`
+
+### Task 2: Add menuCategory query and update beer list query
+
+- **File**: `client/src/pages/BeerPage.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add `trpc.menuCategory.listAvailable.useQuery()` alongside the existing `brewery` and `style` queries (around line 29):
+    ```typescript
+    const { data: menuCategories = [] } = trpc.menuCategory.listAvailable.useQuery();
+    ```
+  - Replace the existing `trpc.beer.list.useQuery({})` call (line 28) with:
+    ```typescript
+    const { data: beers, isLoading, refetch } = trpc.beer.list.useQuery({
+      search: debouncedSearch || undefined,
+      menuCategoryIds: selectedMenuCategories.map(id => parseInt(id)),
+      styleIds: selectedStyles.map(id => parseInt(id)),
+      breweryIds: selectedBreweries.map(id => parseInt(id)),
+    });
+    ```
+- **Mirror**: `client/src/pages/BeerBrowser.tsx:83-94` for query patterns
+- **Validate**: `npm run check`
+
+### Task 3: Add filter UI above the beer list
+
+- **File**: `client/src/pages/BeerPage.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add import for `FilterControls` at the top of the file:
+    ```typescript
+    import { FilterControls } from "@/components/FilterControls";
+    ```
+  - Insert a filter section in the JSX between the header `<div>` (the "Add Beer" button row) and the loading/list section (around line 212, before `{isLoading ? ...}`):
+    ```tsx
+    <div className="space-y-3 p-4 bg-gray-50 rounded-lg border">
+      <Input
+        placeholder="Search beers..."
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+      <div className="grid grid-cols-3 gap-4">
+        <FilterControls
+          selectedMenuCategories={selectedMenuCategories}
+          setSelectedMenuCategories={setSelectedMenuCategories}
+          selectedStyles={selectedStyles}
+          setSelectedStyles={setSelectedStyles}
+          selectedBreweries={selectedBreweries}
+          setSelectedBreweries={setSelectedBreweries}
+          menuCategories={menuCategories}
+          styles={styles ?? []}
+          breweries={breweries ?? []}
+        />
+      </div>
+    </div>
+    ```
+  - `Input` is already imported. `styles` and `breweries` are already fetched. No new imports needed beyond `FilterControls`.
+- **Mirror**: `client/src/pages/BeerBrowser.tsx:205-216` for FilterControls layout
+- **Validate**: `npm run check`
+
+---
+
+## Validation
+
+```bash
+# Type check
+npm run check
+
+# Tests (requires test DB)
+npm test
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Typing in the search input filters the beer list after ~300ms (debounced, server-side)
+- [ ] Selecting menu categories from the multi-select filters the list
+- [ ] Selecting styles from the multi-select filters the list
+- [ ] Selecting breweries from the multi-select filters the list
+- [ ] Multiple active filters apply AND logic (all conditions must match)
+- [ ] Filters reset on page reload (no persistence)
+- [ ] Filter controls are visible on the BeerPage curator tab in a 3-column layout
+- [ ] `npm run check` passes with no type errors

--- a/.agents/reports/beer-page-filter-controls-report.md
+++ b/.agents/reports/beer-page-filter-controls-report.md
@@ -1,0 +1,37 @@
+# Implementation Report
+
+**Plan**: `.agents/plans/completed/beer-page-filter-controls.plan.md`
+**Branch**: `claude/goofy-matsumoto-1d0b3f`
+**Status**: COMPLETE
+
+## Summary
+
+Added filter controls to the BeerPage curator tab. A search input (debounced 300ms) and three multi-select dropdowns (menu category, style, brewery) now sit above the beer list and drive server-side filtering via the existing `beer.list` tRPC endpoint.
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Add filter state + debounced search | `client/src/pages/BeerPage.tsx` | ✅ |
+| 2 | Add menuCategory query, update beer.list query | `client/src/pages/BeerPage.tsx` | ✅ |
+| 3 | Add filter UI (search input + FilterControls grid) | `client/src/pages/BeerPage.tsx` | ✅ |
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check (`npm run check`) | ✅ No errors in BeerPage.tsx (pre-existing errors in other files unrelated to this change) |
+
+## Files Changed
+
+| File | Action | Changes |
+|------|--------|---------|
+| `client/src/pages/BeerPage.tsx` | UPDATE | +31 lines |
+
+## Deviations from Plan
+
+None — implementation matched the plan exactly.
+
+## Tests Written
+
+This feature is frontend-only UI state wiring. No server-side logic was added; the backend filter support was delivered in PR #96. No new tests were required.

--- a/client/src/pages/BeerPage.tsx
+++ b/client/src/pages/BeerPage.tsx
@@ -38,9 +38,9 @@ export default function BeerPage() {
 
   const { data: beers, isLoading, refetch } = trpc.beer.list.useQuery({
     search: debouncedSearch || undefined,
-    menuCategoryIds: selectedMenuCategories.map(id => parseInt(id)),
-    styleIds: selectedStyles.map(id => parseInt(id)),
-    breweryIds: selectedBreweries.map(id => parseInt(id)),
+    menuCategoryIds: selectedMenuCategories.map(id => parseInt(id, 10)),
+    styleIds: selectedStyles.map(id => parseInt(id, 10)),
+    breweryIds: selectedBreweries.map(id => parseInt(id, 10)),
   });
   const { data: breweries } = trpc.brewery.list.useQuery();
   const { data: styles } = trpc.style.list.useQuery();
@@ -250,6 +250,12 @@ export default function BeerPage() {
 
       {isLoading ? (
         <div className="text-center py-8">Loading...</div>
+      ) : beers?.length === 0 ? (
+        <div className="text-center py-8 text-gray-500">
+          {search || selectedMenuCategories.length > 0 || selectedStyles.length > 0 || selectedBreweries.length > 0
+            ? "No beers match your filters."
+            : "No beers found."}
+        </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-2">
           {beers?.map((beer) => (

--- a/client/src/pages/BeerPage.tsx
+++ b/client/src/pages/BeerPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,6 +9,7 @@ import { Plus, Trash2, Edit2 } from "lucide-react";
 import { toast } from "sonner";
 import { SearchableSelect, SearchableSelectOption } from "@/components/ui/searchable-select";
 import { DeleteConfirmDialog } from "@/components/ui/delete-confirm-dialog";
+import { FilterControls } from "@/components/FilterControls";
 
 export default function BeerPage() {
   const [open, setOpen] = useState(false);
@@ -24,10 +25,26 @@ export default function BeerPage() {
     ibu: "",
     status: "out" as "on_tap" | "bottle_can" | "out",
   });
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [selectedMenuCategories, setSelectedMenuCategories] = useState<string[]>([]);
+  const [selectedStyles, setSelectedStyles] = useState<string[]>([]);
+  const [selectedBreweries, setSelectedBreweries] = useState<string[]>([]);
 
-  const { data: beers, isLoading, refetch } = trpc.beer.list.useQuery({});
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { data: beers, isLoading, refetch } = trpc.beer.list.useQuery({
+    search: debouncedSearch || undefined,
+    menuCategoryIds: selectedMenuCategories.map(id => parseInt(id)),
+    styleIds: selectedStyles.map(id => parseInt(id)),
+    breweryIds: selectedBreweries.map(id => parseInt(id)),
+  });
   const { data: breweries } = trpc.brewery.list.useQuery();
   const { data: styles } = trpc.style.list.useQuery();
+  const { data: menuCategories = [] } = trpc.menuCategory.listAvailable.useQuery();
   const createMutation = trpc.beer.create.useMutation();
   const updateMutation = trpc.beer.update.useMutation();
   const deleteMutation = trpc.beer.delete.useMutation();
@@ -208,6 +225,27 @@ export default function BeerPage() {
             </form>
           </DialogContent>
         </Dialog>
+      </div>
+
+      <div className="space-y-3 p-4 bg-gray-50 rounded-lg border">
+        <Input
+          placeholder="Search beers..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <div className="grid grid-cols-3 gap-4">
+          <FilterControls
+            selectedMenuCategories={selectedMenuCategories}
+            setSelectedMenuCategories={setSelectedMenuCategories}
+            selectedStyles={selectedStyles}
+            setSelectedStyles={setSelectedStyles}
+            selectedBreweries={selectedBreweries}
+            setSelectedBreweries={setSelectedBreweries}
+            menuCategories={menuCategories}
+            styles={styles ?? []}
+            breweries={breweries ?? []}
+          />
+        </div>
       </div>
 
       {isLoading ? (


### PR DESCRIPTION
## Summary

- Adds a text search input (debounced 300ms) and multi-select dropdowns for menu category, style, and brewery to the BeerPage curator tab
- Reuses the existing `FilterControls` component — no new component needed
- All filters drive server-side filtering via the `beer.list` tRPC endpoint (added in #96)
- Filters reset on page reload (no persistence)

Closes #97

## Test plan

- [ ] Navigate to the Dashboard → Beers tab as a curator/admin
- [ ] Type in the search box — confirm the beer list updates after ~300ms showing only matching beers
- [ ] Select a menu category from the dropdown — confirm the list filters to that category
- [ ] Select a style — confirm filtering works
- [ ] Select a brewery — confirm filtering works
- [ ] Combine multiple filters — confirm AND logic (only beers matching all active filters appear)
- [ ] Reload the page — confirm all filters are cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)