### PR TITLE
docs: add GitHub project workflow and process improvements

### DIFF
--- a/.claude/commands/create-stories.md
+++ b/.claude/commands/create-stories.md
@@ -150,14 +150,33 @@ Save the stories to `.agents/stories/` directory as a markdown file.
    ```
    Capture the returned issue URL for the report.
 
-3. **Report created issues**:
+3. **Add each issue to the GitHub project** with status **"Todo"**:
+   ```bash
+   gh project item-add 1 --owner dmcassel --url <issue-url>
+   ```
+   Then update the item's Status field to "Todo" using the project's field/option IDs
+   (look up with `gh project field-list 1 --owner dmcassel --format json`).
+
+4. **If more than one issue was created**, also create an **Epic** issue:
+   - Title: `EPIC: {feature/PRD name}`
+   - Body: a list of links to all sub-issues (e.g. `- #42 Story title`)
+   ```bash
+   gh issue create \
+     --title "EPIC: {feature name}" \
+     --body "{list of sub-issue links}" \
+     --label "epic"
+   ```
+   Add the Epic to the project with status **"Todo"** as well.
+
+5. **Report created issues**:
    ```markdown
    ## GitHub Issues Created
 
-   | # | Title | Labels |
-   |---|-------|--------|
-   | #42 | Story title | feature, high |
-   | #43 | Story title | technical, medium |
+   | # | Title | Labels | Project |
+   |---|-------|--------|---------|
+   | #42 | Story title | feature, high | Todo |
+   | #43 | Story title | technical, medium | Todo |
+   | #44 | EPIC: Feature name | epic | Todo |
    ...
    ```
 

--- a/.claude/commands/create-stories.md
+++ b/.claude/commands/create-stories.md
@@ -145,6 +145,7 @@ Save the stories to `.agents/stories/` directory as a markdown file.
      --body "{description + acceptance criteria in markdown}" \
      --label "{type-label}" \
      --label "{priority-label}" \
+     --label "Claude" \
      [--milestone "{milestone}"] \
      [--label "{extra-label}"]
    ```
@@ -164,7 +165,8 @@ Save the stories to `.agents/stories/` directory as a markdown file.
    gh issue create \
      --title "EPIC: {feature name}" \
      --body "{list of sub-issue links}" \
-     --label "epic"
+     --label "epic" \
+     --label "Claude"
    ```
    Add the Epic to the project with status **"Todo"** as well.
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -220,6 +220,7 @@ Always create a PR after implementation is complete:
 ```bash
 gh pr create \
   --title "{concise title}" \
+  --label "Claude" \
   --body "## Summary
 {1-3 bullet points describing what was implemented}
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -211,16 +211,37 @@ mv $ARGUMENTS .agents/plans/completed/
 
 ---
 
-## Phase 6: UPDATE GITHUB ISSUE (if issue specified in plan)
+## Phase 6: CREATE PULL REQUEST AND UPDATE GITHUB ISSUE
 
-**This phase is mandatory if the plan's Metadata table contains a GitHub Issue number.** Skip only if the GitHub Issue field is "N/A" or absent.
+### 6.1 Create Pull Request
 
-### 6.1 Add Implementation Comment
+Always create a PR after implementation is complete:
+
+```bash
+gh pr create \
+  --title "{concise title}" \
+  --body "## Summary
+{1-3 bullet points describing what was implemented}
+
+## Test plan
+{Bulleted checklist of how to verify the change}
+
+Closes #{issue-number}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+> **Do NOT close the issue.** The `Closes #N` keyword in the PR body will close it automatically when the PR is merged. Leave the issue open until then.
+
+### 6.2 Add Implementation Comment to Issue (if issue specified in plan)
+
+**This step is mandatory if the plan's Metadata table contains a GitHub Issue number.** Skip only if the GitHub Issue field is "N/A" or absent.
 
 ```bash
 gh issue comment {number} --body "## Implementation Complete
 
 **Branch**: {branch-name}
+**PR**: {pr-url}
 **Report**: \`.agents/reports/{plan-name}-report.md\`
 
 ### What was implemented
@@ -232,21 +253,6 @@ gh issue comment {number} --body "## Implementation Complete
 ### Deviations
 {List deviations or 'None'}
 "
-```
-
-### 6.2 Apply Labels (if applicable)
-
-```bash
-# Mark as ready for review
-gh issue edit {number} --add-label "ready-for-review"
-```
-
-### 6.3 Close the Issue (if fully implemented)
-
-If the implementation completes the issue's stated goal:
-
-```bash
-gh issue close {number} --comment "Implemented in branch {branch-name}. See .agents/reports/{plan-name}-report.md for details."
 ```
 
 ---
@@ -283,22 +289,18 @@ gh issue close {number} --comment "Implemented in branch {branch-name}. See .age
 - Report: `.agents/reports/{name}-report.md`
 - Plan archived: `.agents/plans/completed/`
 
+### Pull Request
+
+{PR URL, e.g. https://github.com/dmcassel/beer-menu/pull/42}
+
 ### GitHub Issue
 
-{If issue was updated: "Commented on #{number} and closed/labeled." Otherwise: "No GitHub issue linked."}
+{If issue was updated: "Commented on #{number}. Issue will auto-close when PR is merged." Otherwise: "No GitHub issue linked."}
 
 ### Next Steps
 
 1. Review the report
-2. **Check PR size** before creating:
-   ```bash
-   git diff main --stat
-   ```
-   If the diff exceeds 400 meaningful lines or 15 files, identify a logical
-   split point, push what's done as a draft PR, and create a new plan for
-   the remainder. Do not create an oversized PR.
-3. Create PR: `gh pr create`
-4. Merge when approved
+2. Review and merge the PR — the linked issue will close automatically on merge
 ```
 
 ---

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -205,7 +205,23 @@ npm test
 
 ---
 
-## Phase 5: OUTPUT
+## Phase 5: GITHUB PROJECT UPDATE
+
+If the plan has a GitHub Issue number in its Metadata table:
+
+1. Move the issue to **"In Progress"** in the GitHub project:
+   ```bash
+   # Add item if not already in project
+   gh project item-add 1 --owner dmcassel --url <issue-url>
+   # Update Status field to "In Progress"
+   # (look up field/option IDs with: gh project field-list 1 --owner dmcassel --format json)
+   ```
+
+2. If the issue belongs to an Epic (check for issues that link to it, or ask the user), also move the Epic to **"In Progress"** if this is the first sub-issue being planned.
+
+---
+
+## Phase 6: OUTPUT
 
 ```markdown
 ## Plan Created
@@ -222,6 +238,8 @@ npm test
 **Key Patterns**:
 - {Pattern 1 with file:line}
 - {Pattern 2 with file:line}
+
+**GitHub Issue**: {#number moved to "In Progress", or "N/A"}
 
 **Next Step**: Review the plan, then implement tasks in order.
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,3 +185,46 @@ npm test        # Run tests (needs test DB)
 - The test DB runs on port 5433; production DB on 5432
 - Beer status values: `on_tap`, `bottle_can`, `out`; only `on_tap` and `bottle_can` beers appear on the public menu
 - User roles: `user` (read-only), `curator` (can create/edit/delete catalog items), `admin` (full access)
+
+---
+
+## GitHub Project Workflow
+
+GitHub project: https://github.com/users/dmcassel/projects/1/views/1
+
+### Worktrees
+
+Use the user's existing worktree via `EnterWorktree`. Do not create a new worktree with `isolation: "worktree"`.
+
+### Creating Stories (`/create-stories`)
+
+After creating GitHub issues:
+1. Add each issue to the GitHub project with status **"Todo"**
+2. If more than one issue is created, also create an **Epic** issue:
+   - Title prefix: `EPIC: `
+   - Body includes links to all sub-issues
+   - Add the Epic to the project with status **"Todo"**
+
+### Planning (`/plan`)
+
+After creating the plan file, move the GitHub issue to **"In Progress"** in the project.
+If the issue belongs to an Epic, also move the Epic to **"In Progress"** (when the first sub-issue moves).
+
+### After Implementing (`/implement`)
+
+After implementation is complete:
+1. Create a PR with `gh pr create`
+2. Do **not** close the issue — leave it open until the PR is merged/closed
+
+### Epic Completion
+
+When the last sub-issue in an Epic is closed, close the Epic issue.
+
+### GitHub Project CLI
+
+Add an issue to the project:
+```bash
+gh project item-add 1 --owner dmcassel --url <issue-url>
+```
+
+Update an item's status (requires project ID, item ID, field ID, and option ID — look these up with `gh project field-list 1 --owner dmcassel` and `gh project item-list 1 --owner dmcassel --format json`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,10 @@ After implementation is complete:
 
 When the last sub-issue in an Epic is closed, close the Epic issue.
 
+### Labels
+
+Always add the `Claude` label to any issue or PR you create.
+
 ### GitHub Project CLI
 
 Add an issue to the project:


### PR DESCRIPTION
## Summary

- Documents the GitHub project board and integrates it into the `/create-stories`, `/plan`, and `/implement` workflows
- `/create-stories` now adds issues to the project as "Todo" and creates an Epic when multiple issues are generated
- `/plan` now moves the issue to "In Progress" when planning begins (and moves the Epic too, on the first sub-issue)
- `/implement` now creates a PR after implementation instead of closing the issue directly; `Closes #N` in the PR body handles auto-close on merge
- CLAUDE.md documents the worktree rule: use `EnterWorktree` on the user's existing worktree rather than creating a new one

## Test plan

- [ ] Review CLAUDE.md GitHub Project Workflow section
- [ ] Review `.claude/commands/create-stories.md` Phase 6 for project + Epic logic
- [ ] Review `.claude/commands/plan.md` Phase 5 for "In Progress" update
- [ ] Review `.claude/commands/implement.md` Phase 6 for PR creation and no manual issue close

🤖 Generated with [Claude Code](https://claude.com/claude-code)