### PR TITLE
feat: active filter badges and Clear All on BeerPage

### DIFF
--- a/.agents/plans/completed/beer-page-filter-badges.plan.md
+++ b/.agents/plans/completed/beer-page-filter-badges.plan.md
@@ -1,0 +1,211 @@
+# Plan: BeerPage Active Filter Badges and Clear All
+
+## Summary
+
+Add dismissible filter badges and a Clear All button to BeerPage, mirroring the pattern already implemented in BeerBrowser. When any multiselect filter is active, a badge row appears below the filter controls showing each active filter value as a clickable badge; clicking × removes that filter. Clear All resets all four filter state vars (search + 3 multiselects). The badge row hides when no filters are active.
+
+## User Story
+
+As a curator
+I want to see which filters are active as dismissible badges and clear them all at once
+So that I can understand and reset my current filter state without reopening dropdowns
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Type | ENHANCEMENT |
+| Complexity | LOW |
+| Systems Affected | `client/src/pages/BeerPage.tsx` |
+| GitHub Issue | 98 |
+
+---
+
+## Patterns to Follow
+
+### Badge Rendering
+```tsx
+// SOURCE: client/src/pages/BeerBrowser.tsx:220-289
+{hasActiveFilters && (
+  <div className="mt-4 flex items-center gap-2 flex-wrap">
+    {selectedMenuCategories.map(id => {
+      const category = menuCategories.find(c => c.menu_cat_id === parseInt(id));
+      return category ? (
+        <Badge
+          key={`cat-${id}`}
+          variant="secondary"
+          className="cursor-pointer"
+          onClick={() =>
+            setSelectedMenuCategories(selectedMenuCategories.filter(catId => catId !== id))
+          }
+        >
+          {category.name}
+          <X className="w-3 h-3 ml-1" />
+        </Badge>
+      ) : null;
+    })}
+    {/* ...styles, breweries similarly... */}
+    <Button variant="ghost" size="sm" onClick={handleClearFilters} className="text-amber-700 hover:text-amber-900">
+      Clear All
+    </Button>
+  </div>
+)}
+```
+
+### Clear Filters + hasActiveFilters
+```tsx
+// SOURCE: client/src/pages/BeerBrowser.tsx:152-166
+const handleClearFilters = () => {
+  setSelectedMenuCategories([]);
+  setSelectedStyles([]);
+  setSelectedBreweries([]);
+};
+
+const hasActiveFilters =
+  selectedMenuCategories.length > 0 ||
+  selectedStyles.length > 0 ||
+  selectedBreweries.length > 0;
+```
+
+---
+
+## Files to Change
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `client/src/pages/BeerPage.tsx` | UPDATE | Add Badge import, X icon, computed vars, and badge row JSX |
+
+---
+
+## Tasks
+
+### Task 1: Add missing imports
+
+- **File**: `client/src/pages/BeerPage.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add `X` to the lucide-react import (line 8 currently: `{ Plus, Trash2, Edit2 }`)
+  - Add `import { Badge } from "@/components/ui/badge";` after the existing ui imports
+- **Mirror**: `client/src/pages/BeerBrowser.tsx` top-level imports (Badge, X)
+- **Validate**: `npm run check`
+
+### Task 2: Add computed vars before the return statement
+
+- **File**: `client/src/pages/BeerPage.tsx`
+- **Action**: UPDATE
+- **Implement**: Add these two derived values after the existing state declarations (around line 32), before `return`:
+
+  ```tsx
+  const hasActiveFilters =
+    search.length > 0 ||
+    selectedMenuCategories.length > 0 ||
+    selectedStyles.length > 0 ||
+    selectedBreweries.length > 0;
+
+  const handleClearFilters = () => {
+    setSearch("");
+    setSelectedMenuCategories([]);
+    setSelectedStyles([]);
+    setSelectedBreweries([]);
+  };
+  ```
+
+  Note: BeerPage includes `search` in `hasActiveFilters` and `handleClearFilters` (unlike BeerBrowser which has no search input). This is per the issue spec.
+
+- **Mirror**: `client/src/pages/BeerBrowser.tsx:152-166`
+- **Validate**: `npm run check`
+
+### Task 3: Add badge row JSX inside the filter section
+
+- **File**: `client/src/pages/BeerPage.tsx`
+- **Action**: UPDATE
+- **Implement**: After the closing `</div>` of the `grid grid-cols-3` filter controls div (currently line 248), but still inside the outer `bg-gray-50` container div, add:
+
+  ```tsx
+  {hasActiveFilters && (
+    <div className="flex items-center gap-2 flex-wrap">
+      {selectedMenuCategories.map(id => {
+        const category = menuCategories.find(c => c.menu_cat_id === parseInt(id, 10));
+        return category ? (
+          <Badge
+            key={`cat-${id}`}
+            variant="secondary"
+            className="cursor-pointer"
+            onClick={() =>
+              setSelectedMenuCategories(selectedMenuCategories.filter(catId => catId !== id))
+            }
+          >
+            {category.name}
+            <X className="w-3 h-3 ml-1" />
+          </Badge>
+        ) : null;
+      })}
+      {selectedStyles.map(id => {
+        const style = styles?.find(s => s.styleId === parseInt(id, 10));
+        return style ? (
+          <Badge
+            key={`style-${id}`}
+            variant="secondary"
+            className="cursor-pointer"
+            onClick={() =>
+              setSelectedStyles(selectedStyles.filter(styleId => styleId !== id))
+            }
+          >
+            {style.name}
+            <X className="w-3 h-3 ml-1" />
+          </Badge>
+        ) : null;
+      })}
+      {selectedBreweries.map(id => {
+        const brewery = breweries?.find(b => b.breweryId === parseInt(id, 10));
+        return brewery ? (
+          <Badge
+            key={`brewery-${id}`}
+            variant="secondary"
+            className="cursor-pointer"
+            onClick={() =>
+              setSelectedBreweries(selectedBreweries.filter(breweryId => breweryId !== id))
+            }
+          >
+            {brewery.name}
+            <X className="w-3 h-3 ml-1" />
+          </Badge>
+        ) : null;
+      })}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleClearFilters}
+        className="text-amber-700 hover:text-amber-900"
+      >
+        Clear All
+      </Button>
+    </div>
+  )}
+  ```
+
+- **Mirror**: `client/src/pages/BeerBrowser.tsx:220-289`
+- **Validate**: `npm run check`
+
+---
+
+## Validation
+
+```bash
+# Type check
+npm run check
+
+# Format
+npm run format
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] When any filter (category, style, brewery) is active, badges appear below the filter controls
+- [ ] Clicking × on a badge removes only that filter
+- [ ] Clear All button resets search, categories, styles, and breweries
+- [ ] No badges or Clear All shown when no filters are active
+- [ ] Styling matches BeerBrowser (Badge variant="secondary", Button variant="ghost" amber colors)
+- [ ] Type check passes

--- a/.agents/reports/beer-page-filter-badges-report.md
+++ b/.agents/reports/beer-page-filter-badges-report.md
@@ -1,0 +1,38 @@
+# Implementation Report
+
+**Plan**: `.agents/plans/beer-page-filter-badges.plan.md`
+**Branch**: `98/beer-page-filter-badges`
+**Status**: COMPLETE
+
+## Summary
+
+Added dismissible filter badges and a Clear All button to `BeerPage.tsx`, mirroring the existing pattern from `BeerBrowser.tsx`. When any multiselect filter (category, style, brewery) is active, a badge row appears below the filter controls. Clicking × on a badge removes that single filter. Clear All resets all four filter state vars (search + 3 multiselects). The badge row is hidden when no filters are active.
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Add `X` icon and `Badge` imports | `client/src/pages/BeerPage.tsx` | ✅ |
+| 2 | Add `hasActiveFilters` and `handleClearFilters` computed vars | `client/src/pages/BeerPage.tsx` | ✅ |
+| 3 | Add badge row JSX inside filter section | `client/src/pages/BeerPage.tsx` | ✅ |
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check (`npm run check`) | ✅ (no new errors introduced; pre-existing errors in BeerBrowser, Map, Login, server/_core unchanged) |
+
+## Files Changed
+
+| File | Action | Details |
+|------|--------|---------|
+| `client/src/pages/BeerPage.tsx` | UPDATE | +2 imports, +12 lines computed vars, +60 lines badge JSX |
+
+## Deviations from Plan
+
+- Added explicit type annotation `(c: { menu_cat_id: number; name: string })` to the `menuCategories.find` callback to avoid introducing a new implicit-any TS error (the same pattern in BeerBrowser.tsx has this error as a pre-existing issue, but I fixed it in my new code to avoid adding a new error).
+- `hasActiveFilters` includes `search.length > 0` as specified in issue notes, so Clear All button appears even when only the text search is active (though search itself doesn't render a badge, only the multiselect filters do).
+
+## Tests Written
+
+No new tests written — this is a pure UI-only change with no server-side logic or new functions to test. The filtering logic itself (tRPC query with filter params) was already present and tested.

--- a/client/src/pages/BeerPage.tsx
+++ b/client/src/pages/BeerPage.tsx
@@ -5,11 +5,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Plus, Trash2, Edit2 } from "lucide-react";
+import { Plus, Trash2, Edit2, X } from "lucide-react";
 import { toast } from "sonner";
 import { SearchableSelect, SearchableSelectOption } from "@/components/ui/searchable-select";
 import { DeleteConfirmDialog } from "@/components/ui/delete-confirm-dialog";
 import { FilterControls } from "@/components/FilterControls";
+import { Badge } from "@/components/ui/badge";
 
 export default function BeerPage() {
   const [open, setOpen] = useState(false);
@@ -35,6 +36,19 @@ export default function BeerPage() {
     const timer = setTimeout(() => setDebouncedSearch(search), 300);
     return () => clearTimeout(timer);
   }, [search]);
+
+  const hasActiveFilters =
+    search.length > 0 ||
+    selectedMenuCategories.length > 0 ||
+    selectedStyles.length > 0 ||
+    selectedBreweries.length > 0;
+
+  const handleClearFilters = () => {
+    setSearch("");
+    setSelectedMenuCategories([]);
+    setSelectedStyles([]);
+    setSelectedBreweries([]);
+  };
 
   const { data: beers, isLoading, refetch } = trpc.beer.list.useQuery({
     search: debouncedSearch || undefined,
@@ -246,6 +260,66 @@ export default function BeerPage() {
             breweries={breweries ?? []}
           />
         </div>
+        {hasActiveFilters && (
+          <div className="flex items-center gap-2 flex-wrap">
+            {selectedMenuCategories.map(id => {
+              const category = menuCategories.find((c: { menu_cat_id: number; name: string }) => c.menu_cat_id === parseInt(id, 10));
+              return category ? (
+                <Badge
+                  key={`cat-${id}`}
+                  variant="secondary"
+                  className="cursor-pointer"
+                  onClick={() =>
+                    setSelectedMenuCategories(selectedMenuCategories.filter(catId => catId !== id))
+                  }
+                >
+                  {category.name}
+                  <X className="w-3 h-3 ml-1" />
+                </Badge>
+              ) : null;
+            })}
+            {selectedStyles.map(id => {
+              const style = styles?.find(s => s.styleId === parseInt(id, 10));
+              return style ? (
+                <Badge
+                  key={`style-${id}`}
+                  variant="secondary"
+                  className="cursor-pointer"
+                  onClick={() =>
+                    setSelectedStyles(selectedStyles.filter(styleId => styleId !== id))
+                  }
+                >
+                  {style.name}
+                  <X className="w-3 h-3 ml-1" />
+                </Badge>
+              ) : null;
+            })}
+            {selectedBreweries.map(id => {
+              const brewery = breweries?.find(b => b.breweryId === parseInt(id, 10));
+              return brewery ? (
+                <Badge
+                  key={`brewery-${id}`}
+                  variant="secondary"
+                  className="cursor-pointer"
+                  onClick={() =>
+                    setSelectedBreweries(selectedBreweries.filter(breweryId => breweryId !== id))
+                  }
+                >
+                  {brewery.name}
+                  <X className="w-3 h-3 ml-1" />
+                </Badge>
+              ) : null;
+            })}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleClearFilters}
+              className="text-amber-700 hover:text-amber-900"
+            >
+              Clear All
+            </Button>
+          </div>
+        )}
       </div>
 
       {isLoading ? (


### PR DESCRIPTION
## Summary

- Adds dismissible filter badges below the filter controls on the curator BeerPage when any multiselect filter (category, style, brewery) is active
- Clicking × on a badge removes that individual filter; Clear All resets search and all three multiselect filters
- Badge row is hidden when no filters are active; styling mirrors BeerBrowser's existing badge display

## Test plan

- [ ] Select a Style filter on the Beers admin page — a badge appears with the style name and ×
- [ ] Click the × on the badge — that filter is removed and the list updates
- [ ] Select multiple filters across categories — one badge per active filter value appears
- [ ] Click Clear All — all filters reset, full beer list shown, badges hidden
- [ ] Confirm no badges/Clear All shown when no filters are active
- [ ] Search text clears when Clear All is clicked

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)