### PR TITLE
Add winery filter to wine browse page

### DIFF
--- a/.agents/plans/completed/winery-filter-wine-browse.plan.md
+++ b/.agents/plans/completed/winery-filter-wine-browse.plan.md
@@ -1,0 +1,152 @@
+# Plan: Winery Filter on Wine Browse Page
+
+## Summary
+
+Add a winery filter to the public wine browse page (`WinePage`). The backend already supports `wineryIds` filtering via `wine.listAvailable`; this plan is purely frontend work. We extend `WineFilterControls` to accept and render a winery multi-select, then wire up state, badge display, and the tRPC query in `WinePage`.
+
+## User Story
+
+As a user browsing the public wine menu
+I want to filter wines by winery
+So that I can quickly see all wines from a specific producer
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Type | ENHANCEMENT |
+| Complexity | LOW |
+| Systems Affected | Frontend only (WinePage, WineFilterControls) |
+| GitHub Issue | 107 |
+
+---
+
+## Patterns to Follow
+
+### Location filter in WineFilterControls (the model to mirror)
+```typescript
+// SOURCE: client/src/components/WineFilterControls.tsx:3-17
+interface WineFilterControlsProps {
+  selectedLocations: string[];
+  setSelectedLocations: (value: string[]) => void;
+  locations: Array<{ locationId: number; fullPath: string }>;
+}
+
+const locationOptions: MultiSelectOption[] = locations.map(loc => ({
+  label: loc.fullPath,
+  value: loc.locationId.toString(),
+}));
+
+<MultiSelect
+  options={locationOptions}
+  selected={selectedLocations}
+  onChange={setSelectedLocations}
+  placeholder="All Locations"
+/>
+```
+
+### Winery fetch in curation form (how to get winery list)
+```typescript
+// SOURCE: client/src/pages/ManageWinePage.tsx:33-44
+const { data: wineries } = trpc.winery.list.useQuery();
+
+const wineryOptions: SearchableSelectOption[] =
+  wineries?.map((w: any) => ({
+    label: w.name,
+    value: w.wineryId.toString(),
+  })) || [];
+```
+
+### Active filter badge pattern
+```tsx
+// SOURCE: client/src/pages/WinePage.tsx:133-152
+{selectedLocations.map(id => {
+  const loc = locations.find(l => l.locationId === parseInt(id));
+  return loc ? (
+    <Badge
+      key={`loc-${id}`}
+      variant="secondary"
+      className="cursor-pointer"
+      onClick={() =>
+        setSelectedLocations(selectedLocations.filter(locId => locId !== id))
+      }
+    >
+      {loc.fullPath}
+      <X className="w-3 h-3 ml-1" />
+    </Badge>
+  ) : null;
+})}
+```
+
+### Backend tRPC signature (no changes needed)
+```typescript
+// SOURCE: server/routers.ts (wine.listAvailable)
+z.object({
+  locationIds: z.array(z.number()).optional(),
+  wineryIds: z.array(z.number()).optional(),
+})
+```
+
+---
+
+## Files to Change
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `client/src/components/WineFilterControls.tsx` | UPDATE | Add winery props and MultiSelect |
+| `client/src/pages/WinePage.tsx` | UPDATE | Add winery state, fetch, query param, badges |
+
+---
+
+## Tasks
+
+### Task 1: Extend WineFilterControls with winery filter
+
+- **File**: `client/src/components/WineFilterControls.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add `selectedWineries`, `setSelectedWineries`, and `wineries: Array<{ wineryId: number; name: string }>` to props interface
+  - Build `wineryOptions: MultiSelectOption[]` mapping `wineryId.toString()` → `name`
+  - Render a second `<div>` block below Location, with label "Winery" and `<MultiSelect>` using the same pattern as Location
+- **Mirror**: `client/src/components/WineFilterControls.tsx:3-31` — follow the exact same structure for the new block
+- **Validate**: `npm run check`
+
+### Task 2: Wire winery filter into WinePage
+
+- **File**: `client/src/pages/WinePage.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  1. Add state: `const [selectedWineries, setSelectedWineries] = useState<string[]>([]);`
+  2. Fetch wineries: `const { data: wineries = [] } = trpc.winery.list.useQuery();`
+  3. Update the `wine.listAvailable` query to pass `wineryIds: selectedWineries.map(id => parseInt(id))`
+  4. Update `hasActiveFilters` to include `selectedWineries.length > 0`
+  5. Update `activeFilterCount` to sum both arrays: `selectedLocations.length + selectedWineries.length`
+  6. Update `handleClearFilters` to also call `setSelectedWineries([])`
+  7. Pass `selectedWineries`, `setSelectedWineries`, and `wineries` to both `<WineFilterControls>` usages (desktop grid and mobile Sheet)
+  8. Add winery active-filter badges in the badge section, mirroring the location badge pattern (key prefix `winery-`, display `winery.name`)
+  9. Update the "No wines match" helper text to reference "filters" generically instead of "location filter" only
+- **Mirror**: `client/src/pages/WinePage.tsx:66-84,122-162` — mirror existing location filter state and badge patterns exactly
+- **Validate**: `npm run check`
+
+---
+
+## Validation
+
+```bash
+# Type check
+npm run check
+
+# Tests (no new tests needed — backend is already tested; this is UI wiring)
+npm test
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Winery filter visible in desktop filter grid and mobile drawer
+- [ ] Selecting a winery shows only wines from that winery
+- [ ] Selecting winery + location shows wines matching both filters
+- [ ] Clearing a winery badge removes it; Clear All resets both filters
+- [ ] Filter count badge on mobile button reflects total active filters (winery + location)
+- [ ] Type check passes (`npm run check`)

--- a/.agents/reports/winery-filter-wine-browse-report.md
+++ b/.agents/reports/winery-filter-wine-browse-report.md
@@ -1,0 +1,39 @@
+# Implementation Report
+
+**Plan**: `.agents/plans/completed/winery-filter-wine-browse.plan.md`
+**Branch**: `107/winery-filter-wine-browse`
+**Status**: COMPLETE
+
+## Summary
+
+Added a winery filter to the public wine browse page. Extended `WineFilterControls` with winery props and a `MultiSelect` dropdown, then wired up state management, the `wineryIds` query parameter, active-filter badges (with click-to-remove), and mobile drawer support in `WinePage`. No backend changes were needed — the `wine.listAvailable` tRPC procedure already accepted `wineryIds`.
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Add winery props and MultiSelect to WineFilterControls | `client/src/components/WineFilterControls.tsx` | ✅ |
+| 2 | Wire winery state, fetch, query param, badges into WinePage | `client/src/pages/WinePage.tsx` | ✅ |
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check (`npm run check`) | ✅ No new errors (15 pre-existing, unrelated) |
+| Tests (`npm test`) | ✅ 74 passed |
+| E2E smoke test | ✅ Both Location + Winery filters visible and rendering |
+
+## Files Changed
+
+| File | Action | Change |
+|------|--------|--------|
+| `client/src/components/WineFilterControls.tsx` | UPDATE | +22 lines: added winery props to interface, `wineryOptions` mapping, Winery `<MultiSelect>` block |
+| `client/src/pages/WinePage.tsx` | UPDATE | +28/-4 lines: added winery state, `trpc.winery.list` query, `wineryIds` query param, winery badges, updated counts, clear handler, and empty-state text |
+
+## Deviations from Plan
+
+None — implementation matched the plan exactly.
+
+## Tests Written
+
+No new test files were needed. This feature is pure frontend UI wiring; the backend filtering logic (`getAvailableWinesFiltered` with `wineryIds`) is already covered by the existing 74 server-side tests.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "beer-menu-dev",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["cross-env", "NODE_ENV=development", "tsx", "watch", "--env-file=.env.local", "server/_core/index.ts"],
+      "port": 3000
+    }
+  ]
+}

--- a/client/src/components/WineFilterControls.tsx
+++ b/client/src/components/WineFilterControls.tsx
@@ -4,16 +4,27 @@ interface WineFilterControlsProps {
   selectedLocations: string[];
   setSelectedLocations: (value: string[]) => void;
   locations: Array<{ locationId: number; fullPath: string }>;
+  selectedWineries: string[];
+  setSelectedWineries: (value: string[]) => void;
+  wineries: Array<{ wineryId: number; name: string }>;
 }
 
 export function WineFilterControls({
   selectedLocations,
   setSelectedLocations,
   locations,
+  selectedWineries,
+  setSelectedWineries,
+  wineries,
 }: WineFilterControlsProps) {
   const locationOptions: MultiSelectOption[] = locations.map(loc => ({
     label: loc.fullPath,
     value: loc.locationId.toString(),
+  }));
+
+  const wineryOptions: MultiSelectOption[] = wineries.map(w => ({
+    label: w.name,
+    value: w.wineryId.toString(),
   }));
 
   return (
@@ -27,6 +38,17 @@ export function WineFilterControls({
           selected={selectedLocations}
           onChange={setSelectedLocations}
           placeholder="All Locations"
+        />
+      </div>
+      <div>
+        <label className="text-sm font-medium text-gray-700 mb-2 block">
+          Winery
+        </label>
+        <MultiSelect
+          options={wineryOptions}
+          selected={selectedWineries}
+          onChange={setSelectedWineries}
+          placeholder="All Wineries"
         />
       </div>
     </>

--- a/client/src/pages/WinePage.tsx
+++ b/client/src/pages/WinePage.tsx
@@ -64,23 +64,31 @@ function WineHeader() {
 
 export default function WinePage() {
   const [selectedLocations, setSelectedLocations] = useState<string[]>([]);
+  const [selectedWineries, setSelectedWineries] = useState<string[]>([]);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
 
-  // Fetch available wines, filtered at the database level by selected location IDs
+  // Fetch available wines, filtered at the database level by selected location and winery IDs
   const { data: availableWines = [], isLoading } =
     trpc.wine.listAvailable.useQuery({
       locationIds: selectedLocations.map(id => parseInt(id)),
+      wineryIds: selectedWineries.map(id => parseInt(id)),
     });
 
   // Fetch only locations that have available wines (for filter options)
   const { data: locations = [] } = trpc.location.listAvailable.useQuery();
 
+  // Fetch all wineries (for filter options)
+  const { data: wineries = [] } = trpc.winery.list.useQuery();
+
   const handleClearFilters = () => {
     setSelectedLocations([]);
+    setSelectedWineries([]);
   };
 
-  const hasActiveFilters = selectedLocations.length > 0;
-  const activeFilterCount = selectedLocations.length;
+  const hasActiveFilters =
+    selectedLocations.length > 0 || selectedWineries.length > 0;
+  const activeFilterCount =
+    selectedLocations.length + selectedWineries.length;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 to-pink-50">
@@ -124,6 +132,9 @@ export default function WinePage() {
               selectedLocations={selectedLocations}
               setSelectedLocations={setSelectedLocations}
               locations={locations}
+              selectedWineries={selectedWineries}
+              setSelectedWineries={setSelectedWineries}
+              wineries={wineries}
             />
           </div>
 
@@ -146,6 +157,26 @@ export default function WinePage() {
                     }
                   >
                     {loc.fullPath}
+                    <X className="w-3 h-3 ml-1" />
+                  </Badge>
+                ) : null;
+              })}
+              {selectedWineries.map(id => {
+                const winery = wineries.find(
+                  w => w.wineryId === parseInt(id)
+                );
+                return winery ? (
+                  <Badge
+                    key={`winery-${id}`}
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() =>
+                      setSelectedWineries(
+                        selectedWineries.filter(wId => wId !== id)
+                      )
+                    }
+                  >
+                    {winery.name}
                     <X className="w-3 h-3 ml-1" />
                   </Badge>
                 ) : null;
@@ -174,6 +205,9 @@ export default function WinePage() {
               selectedLocations={selectedLocations}
               setSelectedLocations={setSelectedLocations}
               locations={locations}
+              selectedWineries={selectedWineries}
+              setSelectedWineries={setSelectedWineries}
+              wineries={wineries}
             />
             {hasActiveFilters && (
               <Button
@@ -205,7 +239,7 @@ export default function WinePage() {
               </p>
               <p className="text-gray-600">
                 {hasActiveFilters
-                  ? "Try adjusting or clearing your location filter."
+                  ? "Try adjusting or clearing your filters."
                   : "There are currently no wines with bottles in stock."}
               </p>
             </CardContent>


### PR DESCRIPTION
## Summary

- Added a **Winery** MultiSelect filter to the wine browse page alongside the existing Location filter
- Wires up `wineryIds` to `trpc.wine.listAvailable` (backend already supported this)
- Active winery selections show as removable badges; filter count badge on mobile is updated; Clear All resets both filters
- Works in both desktop grid and mobile bottom-sheet drawer

## Test plan

- [ ] Navigate to `/wine` — confirm **Location** and **Winery** dropdowns appear side-by-side
- [ ] Select a winery — confirm only wines from that winery are shown
- [ ] Select both a winery and a location — confirm both filters apply simultaneously
- [ ] Click a winery badge — confirm it clears that filter individually
- [ ] Click **Clear All** — confirm both filters reset
- [ ] On mobile viewport — open the filter drawer and confirm the Winery filter is accessible

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)