### PR TITLE
chore: update plan and review skill workflows

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -38,7 +38,21 @@ Transform the input into a battle-tested implementation plan through codebase ex
 
 ---
 
-## Phase 2: EXPLORE
+## Phase 2: SYNC CODEBASE
+
+Before exploring, ensure the codebase is up to date:
+
+```bash
+# If not on main, switch to it
+git checkout main
+
+# Pull latest changes and prune stale remote branches
+git pull -p
+```
+
+---
+
+## Phase 3: EXPLORE
 
 ### Study the Codebase
 
@@ -61,7 +75,7 @@ Use the Explore agent to find:
 
 ---
 
-## Phase 3: DESIGN
+## Phase 4: DESIGN
 
 ### Map the Changes
 
@@ -91,7 +105,7 @@ Each plan should be completable as a PR reviewable in under 30 minutes.
 
 ---
 
-## Phase 4: GENERATE
+## Phase 5: GENERATE
 
 ### Create Plan File
 
@@ -205,7 +219,7 @@ npm test
 
 ---
 
-## Phase 5: GITHUB PROJECT UPDATE
+## Phase 6: GITHUB PROJECT UPDATE
 
 If the plan has a GitHub Issue number in its Metadata table:
 
@@ -221,7 +235,7 @@ If the plan has a GitHub Issue number in its Metadata table:
 
 ---
 
-## Phase 6: OUTPUT
+## Phase 7: OUTPUT
 
 ```markdown
 ## Plan Created

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -182,7 +182,21 @@ gh pr review {NUMBER} --comment --body-file .agents/reviews/pr-{NUMBER}-review.m
 
 ---
 
-## Phase 6: OUTPUT
+## Phase 6: APPLY CHANGES (if requested)
+
+If the user asks you to make a code change based on findings from this review:
+
+1. Make the change on the **same branch** as the code being reviewed (for a PR, check out that branch first).
+2. Commit the change with a clear message referencing the review finding.
+3. Push the branch to GitHub:
+
+```bash
+git push
+```
+
+---
+
+## Phase 7: OUTPUT
 
 ```markdown
 ## Review Complete


### PR DESCRIPTION
## Summary

- **plan skill**: Added a new Phase 2 "SYNC CODEBASE" step that checks out `main` (if not already on it) and runs `git pull -p` before exploring the codebase. This ensures planning always starts from the latest code. Subsequent phases renumbered 3–7.
- **review skill**: Added a new Phase 6 "APPLY CHANGES" step that instructs switching to the PR's branch, committing any fix made during review, and pushing to GitHub.

## Reviewer Notes

These are process-only changes to the skill markdown files — no application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)