### PR TITLE
Add DB-level filters to wine curation page

### DIFF
--- a/.agents/plans/completed/wine-curation-filters.plan.md
+++ b/.agents/plans/completed/wine-curation-filters.plan.md
@@ -1,0 +1,371 @@
+# Plan: Wine Curation Filters
+
+## Summary
+
+Add winery, location, and text search filters to `ManageWinePage.tsx` with filtering at the database level. `getAllWines()` in `db_wine.ts` is updated to accept optional filter params and build WHERE clauses in the DB (including a recursive CTE for location hierarchy, matching `getAvailableWinesFiltered`'s pattern). `wine.list` in `routers.ts` gains an input schema to pass those params through. `ManageWinePage.tsx` adds filter state and passes it directly to the tRPC query — no client-side `useMemo` filtering needed. The filter UI mirrors `WinePage`: desktop grid, mobile Sheet drawer, and active-filter badges.
+
+## Filter Semantics
+
+- **Within a dimension** (e.g., two wineries selected): OR — show wines from winery A **or** winery B. Implemented via `inArray(wine.wineryId, wineryIds)`.
+- **Across dimensions** (e.g., winery + location both set): AND — show wines that satisfy **all** active filters simultaneously. Implemented by combining each dimension's condition with `and()`.
+- Example: wineries [A, B] + location [France] + search "cab" → wines from (A or B) that are in France and match "cab".
+
+## User Story
+
+As a curator,
+I want to filter the wine curation page by winery, location, and text search,
+So that I can quickly find specific wines when updating inventory after a new shipment.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Type | ENHANCEMENT |
+| Complexity | MEDIUM |
+| Systems Affected | `server/db_wine.ts`, `server/routers.ts`, `client/src/pages/ManageWinePage.tsx` |
+| GitHub Issue | 108 |
+
+---
+
+## Patterns to Follow
+
+### DB filter function with CTE (location hierarchy)
+```typescript
+// SOURCE: server/db_wine.ts:477-563
+// getAvailableWinesFiltered — use same recursive CTE approach,
+// but drop the stock check (refrigerated>0 / cellared>0).
+// Add text search as ilike on label, winery name, and EXISTS on varietal name.
+export async function getAllWines(filters?: {
+  wineryIds?: number[];
+  locationIds?: number[];
+  search?: string;
+})
+```
+
+### Router input schema
+```typescript
+// SOURCE: server/routers.ts:366-373  (listAvailable pattern)
+list: publicProcedure
+  .input(
+    z.object({
+      wineryIds: z.array(z.number()).optional(),
+      locationIds: z.array(z.number()).optional(),
+      search: z.string().optional(),
+    })
+  )
+  .query(({ input }) => dbWine.getAllWines(input)),
+```
+
+### Filter state + query in page
+```typescript
+// SOURCE: client/src/pages/WinePage.tsx:66-75
+const [selectedLocations, setSelectedLocations] = useState<string[]>([]);
+const [selectedWineries, setSelectedWineries] = useState<string[]>([]);
+const [isFilterOpen, setIsFilterOpen] = useState(false);
+const [textSearch, setTextSearch] = useState("");
+
+const { data: wines, isLoading, refetch } = trpc.wine.list.useQuery({
+  wineryIds: selectedWineries.map(id => parseInt(id, 10)),
+  locationIds: selectedLocations.map(id => parseInt(id, 10)),
+  search: textSearch.trim() || undefined,
+});
+```
+
+### WineFilterControls usage + mobile Sheet
+```typescript
+// SOURCE: client/src/pages/WinePage.tsx:130-223
+// Desktop: hidden md:grid md:grid-cols-3 gap-4
+// Mobile: Sheet open={isFilterOpen} side="bottom" h-[85vh]
+// Both use <WineFilterControls ... /> and the text search <Input />
+```
+
+### Active filter badges
+```typescript
+// SOURCE: client/src/pages/WinePage.tsx:142-193
+// selectedLocations and selectedWineries render dismissible <Badge> per value.
+// textSearch renders a quoted badge. Clear All resets all state.
+```
+
+---
+
+## Files to Change
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `server/db_wine.ts` | UPDATE | Add optional filter params to `getAllWines()` |
+| `server/routers.ts` | UPDATE | Add input schema to `wine.list` procedure |
+| `client/src/pages/ManageWinePage.tsx` | UPDATE | Filter state, query params, filter UI |
+
+---
+
+## Tasks
+
+### Task 1: Update `getAllWines()` to accept and apply filters
+
+- **File**: `server/db_wine.ts`
+- **Action**: UPDATE
+- **Implement**: Change the signature to `getAllWines(filters?: { wineryIds?: number[]; locationIds?: number[]; search?: string; })`. Build WHERE conditions at the DB level:
+
+  **When `locationIds` is non-empty**: use a raw SQL recursive CTE (same structure as `getAvailableWinesFiltered` lines 490–525) but without the stock check. The CTE expands all selected location IDs to their descendants; the wine matches if its `location_id` OR its winery's `location_id` is in that set (OR within the location dimension). Append `wineryIds` and `search` as additional AND clauses in the raw SQL (cross-dimension AND semantics): `AND w.winery_id IN (...)` and `AND (w.label ILIKE '%…%' OR wr.name ILIKE '%…%' OR EXISTS (varietal subquery))`.
+
+  **When `locationIds` is empty**: use Drizzle ORM. Build one condition per active dimension, then combine all dimensions with `and()` (cross-dimension AND semantics):
+  - Winery: `wineryIds?.length ? inArray(wine.wineryId, wineryIds) : undefined` — `inArray` is OR across all selected winery IDs.
+  - Search (label/winery name): `search ? or(ilike(wine.label, \`%${search}%\`), ilike(winery.name, \`%${search}%\`)) : undefined`
+  - Search (varietal name): `search ? sql\`EXISTS (SELECT 1 FROM wine_varietal wv JOIN varietal v ON wv.varietal_id = v.varietal_id WHERE wv.wine_id = ${wine.wineId} AND v.name ILIKE ${search})\` : undefined`
+
+  Combine the label/winery/varietal search sub-conditions with `or()` (a wine matches search if any field matches). Then wrap all active dimension conditions in `and()`. Filter out `undefined` values before passing to `where()`.
+
+  The varietal attachment loop (N+1 queries at lines 195–211) remains unchanged.
+
+- **Mirror**: `server/db_wine.ts:477-563` — follow the same two-path structure (CTE vs Drizzle ORM)
+- **Validate**: `npm run check`
+
+### Task 2: Add input schema to `wine.list` router procedure
+
+- **File**: `server/routers.ts`
+- **Action**: UPDATE
+- **Implement**: Replace the current no-input `list` procedure:
+  ```typescript
+  // Before:
+  list: publicProcedure.query(() => dbWine.getAllWines()),
+
+  // After:
+  list: publicProcedure
+    .input(
+      z.object({
+        wineryIds: z.array(z.number()).optional(),
+        locationIds: z.array(z.number()).optional(),
+        search: z.string().optional(),
+      })
+    )
+    .query(({ input }) => dbWine.getAllWines(input)),
+  ```
+- **Mirror**: `server/routers.ts:366-373` — exact same shape as `listAvailable`
+- **Validate**: `npm run check`
+
+### Task 3: Add filter state and wire query in ManageWinePage
+
+- **File**: `client/src/pages/ManageWinePage.tsx`
+- **Action**: UPDATE
+- **Implement**: After the existing `useState` declarations (around line 20), add:
+  ```typescript
+  const [selectedWineries, setSelectedWineries] = useState<string[]>([]);
+  const [selectedLocations, setSelectedLocations] = useState<string[]>([]);
+  const [textSearch, setTextSearch] = useState("");
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  ```
+  Update the existing `trpc.wine.list.useQuery()` call (line 32) to pass filter params:
+  ```typescript
+  const { data: wines, isLoading, refetch } = trpc.wine.list.useQuery({
+    wineryIds: selectedWineries.map(id => parseInt(id, 10)),
+    locationIds: selectedLocations.map(id => parseInt(id, 10)),
+    search: textSearch.trim() || undefined,
+  });
+  ```
+  Add derived values after the query:
+  ```typescript
+  const hasActiveFilters =
+    selectedWineries.length > 0 || selectedLocations.length > 0 || textSearch.trim().length > 0;
+  const activeFilterCount =
+    selectedWineries.length + selectedLocations.length + (textSearch.trim() ? 1 : 0);
+
+  const handleClearFilters = () => {
+    setSelectedWineries([]);
+    setSelectedLocations([]);
+    setTextSearch("");
+  };
+  ```
+- **Mirror**: `client/src/pages/WinePage.tsx:66-91`
+- **Validate**: `npm run check`
+
+### Task 4: Add imports
+
+- **File**: `client/src/pages/ManageWinePage.tsx`
+- **Action**: UPDATE
+- **Implement**: Add to the existing import block:
+  - From `"lucide-react"`: add `Filter`, `X`
+  - From `"@/components/ui/badge"`: add `Badge`
+  - From `"@/components/ui/sheet"`: add `Sheet`, `SheetContent`, `SheetHeader`, `SheetTitle`
+  - From `"@/components/WineFilterControls"`: add `WineFilterControls`
+- **Mirror**: `client/src/pages/WinePage.tsx:1-15` — check which import lines to mirror
+- **Validate**: `npm run check`
+
+### Task 5: Add desktop filter row and active filter badges to the JSX
+
+- **File**: `client/src/pages/ManageWinePage.tsx`
+- **Action**: UPDATE
+- **Implement**: Between the existing header row (`<div className="flex justify-between items-center">`) and the loading/grid section, insert:
+
+  1. **Mobile filter button** — add inside the header row next to the "Add Wine" Dialog trigger:
+  ```tsx
+  <Button
+    variant="outline"
+    size="sm"
+    onClick={() => setIsFilterOpen(true)}
+    className="md:hidden relative"
+  >
+    <Filter className="w-4 h-4" />
+    {activeFilterCount > 0 && (
+      <Badge
+        variant="destructive"
+        className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-xs"
+      >
+        {activeFilterCount}
+      </Badge>
+    )}
+  </Button>
+  ```
+
+  2. **Desktop filter grid** — after the header row div:
+  ```tsx
+  <div className="hidden md:grid md:grid-cols-3 gap-4 mt-4">
+    <WineFilterControls
+      selectedLocations={selectedLocations}
+      setSelectedLocations={setSelectedLocations}
+      locations={locations ?? []}
+      selectedWineries={selectedWineries}
+      setSelectedWineries={setSelectedWineries}
+      wineries={wineries ?? []}
+    />
+    <div>
+      <label className="text-sm font-medium text-gray-700 mb-2 block">Search</label>
+      <Input
+        placeholder="Label, winery, or varietal..."
+        value={textSearch}
+        onChange={e => setTextSearch(e.target.value)}
+      />
+    </div>
+  </div>
+  ```
+
+  3. **Active filter badges** — after the desktop filter grid:
+  ```tsx
+  {hasActiveFilters && (
+    <div className="mt-3 flex items-center gap-2 flex-wrap">
+      {selectedLocations.map(id => {
+        const loc = (locations ?? []).find(l => l.locationId === parseInt(id, 10));
+        return loc ? (
+          <Badge
+            key={`loc-${id}`}
+            variant="secondary"
+            className="cursor-pointer"
+            onClick={() => setSelectedLocations(selectedLocations.filter(x => x !== id))}
+          >
+            {loc.fullPath}<X className="w-3 h-3 ml-1" />
+          </Badge>
+        ) : null;
+      })}
+      {selectedWineries.map(id => {
+        const w = (wineries ?? []).find(w => w.wineryId === parseInt(id, 10));
+        return w ? (
+          <Badge
+            key={`winery-${id}`}
+            variant="secondary"
+            className="cursor-pointer"
+            onClick={() => setSelectedWineries(selectedWineries.filter(x => x !== id))}
+          >
+            {w.name}<X className="w-3 h-3 ml-1" />
+          </Badge>
+        ) : null;
+      })}
+      {textSearch.trim() && (
+        <Badge
+          variant="secondary"
+          className="cursor-pointer"
+          onClick={() => setTextSearch("")}
+        >
+          "{textSearch}"<X className="w-3 h-3 ml-1" />
+        </Badge>
+      )}
+      <Button variant="ghost" size="sm" onClick={handleClearFilters}>
+        Clear All
+      </Button>
+    </div>
+  )}
+  ```
+- **Mirror**: `client/src/pages/WinePage.tsx:107-193`
+- **Validate**: `npm run check`
+
+### Task 6: Add mobile Sheet drawer
+
+- **File**: `client/src/pages/ManageWinePage.tsx`
+- **Action**: UPDATE
+- **Implement**: Before the closing `</div>` of the page (after the `DeleteConfirmDialog`), add:
+  ```tsx
+  <Sheet open={isFilterOpen} onOpenChange={setIsFilterOpen} modal={false}>
+    <SheetContent side="bottom" className="h-[85vh]">
+      <SheetHeader>
+        <SheetTitle>Filter Wines</SheetTitle>
+      </SheetHeader>
+      <div className="space-y-4 mt-6">
+        <WineFilterControls
+          selectedLocations={selectedLocations}
+          setSelectedLocations={setSelectedLocations}
+          locations={locations ?? []}
+          selectedWineries={selectedWineries}
+          setSelectedWineries={setSelectedWineries}
+          wineries={wineries ?? []}
+        />
+        <div>
+          <label className="text-sm font-medium text-gray-700 mb-2 block">Search</label>
+          <Input
+            placeholder="Label, winery, or varietal..."
+            value={textSearch}
+            onChange={e => setTextSearch(e.target.value)}
+          />
+        </div>
+        {hasActiveFilters && (
+          <Button variant="outline" onClick={handleClearFilters} className="w-full">
+            Clear All Filters
+          </Button>
+        )}
+      </div>
+    </SheetContent>
+  </Sheet>
+  ```
+- **Mirror**: `client/src/pages/WinePage.tsx:198-223`
+- **Validate**: `npm run check`
+
+### Task 7: Update the wine grid render to use filtered results
+
+- **File**: `client/src/pages/ManageWinePage.tsx`
+- **Action**: UPDATE
+- **Implement**: The `wines` array from the query now reflects filters, so no structural change is needed to the grid. Add an empty-state message when `!isLoading && wines?.length === 0`:
+  ```tsx
+  {!isLoading && wines?.length === 0 && (
+    <p className="col-span-full text-center py-8 text-gray-500">
+      {hasActiveFilters ? "No wines match your filters." : "No wines found."}
+    </p>
+  )}
+  ```
+  Place this inside the `<div className="grid ...">` before the `wines?.map(...)` call.
+- **Mirror**: `client/src/pages/WinePage.tsx:231-238`
+- **Validate**: `npm run check`
+
+---
+
+## Validation
+
+```bash
+# Type check
+npm run check
+
+# Tests
+npm test
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Selecting a winery filter re-fetches and shows only wines from that winery
+- [ ] Selecting a location filter re-fetches and shows wines where wine's location OR winery's location is within that hierarchy
+- [ ] Text search re-fetches and filters by label, winery name, and varietal name (case-insensitive, DB-level)
+- [ ] Multiple values within the same filter (e.g., two wineries) show wines matching any of them (OR)
+- [ ] Multiple filter dimensions active simultaneously show only wines satisfying all of them (AND)
+- [ ] Clearing any filter immediately re-fetches and updates the list
+- [ ] On mobile, filters are accessible via the Sheet drawer without horizontal scrolling
+- [ ] Active filters shown as removable badges
+- [ ] Empty state message shown when no wines match
+- [ ] Type check passes (`npm run check`)
+- [ ] Tests pass (`npm test`)

--- a/.agents/reports/wine-curation-filters-report.md
+++ b/.agents/reports/wine-curation-filters-report.md
@@ -1,0 +1,47 @@
+# Implementation Report
+
+**Plan**: `.agents/plans/wine-curation-filters.plan.md`
+**Branch**: `108/wine-curation-filters`
+**Status**: COMPLETE
+
+## Summary
+
+Added winery, location, and text search filters to the wine curation page (`ManageWinePage.tsx`). Filtering happens at the database level: `getAllWines()` now accepts optional `wineryIds`, `locationIds`, and `search` params and builds WHERE clauses in PostgreSQL, using the same recursive CTE pattern as `getAvailableWinesFiltered` for location hierarchy. The `wine.list` tRPC procedure was updated with a matching input schema. The UI mirrors the `WinePage` pattern: a 3-column desktop filter grid, a mobile Sheet drawer, and dismissible active-filter badges.
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Update `getAllWines()` to accept and apply filters | `server/db_wine.ts` | ✅ |
+| 2 | Add input schema to `wine.list` router procedure | `server/routers.ts` | ✅ |
+| 3 | Add filter state and wire query | `client/src/pages/ManageWinePage.tsx` | ✅ |
+| 4 | Add imports | `client/src/pages/ManageWinePage.tsx` | ✅ |
+| 5 | Desktop filter row + active filter badges | `client/src/pages/ManageWinePage.tsx` | ✅ |
+| 6 | Mobile Sheet drawer | `client/src/pages/ManageWinePage.tsx` | ✅ |
+| 7 | Empty-state message for no results | `client/src/pages/ManageWinePage.tsx` | ✅ |
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check (`npm run check`) | ✅ (only pre-existing errors from issue #114) |
+| Tests (`npm test`) | ✅ 86 passed (74 pre-existing + 12 new) |
+
+## Files Changed
+
+| File | Action | Notes |
+|------|--------|-------|
+| `server/db_wine.ts` | UPDATE | Added `ilike` import; rewrote `getAllWines()` with two-path filter logic (CTE for location, Drizzle ORM otherwise) |
+| `server/routers.ts` | UPDATE | Added `wineryIds`, `locationIds`, `search` input schema to `wine.list` |
+| `server/db_wine.test.ts` | UPDATE | Added 12 new tests for `getAllWines()` filter combinations |
+| `client/src/pages/ManageWinePage.tsx` | UPDATE | Filter state, parameterized query, imports, desktop grid, mobile Sheet, active badges, empty state |
+
+## Deviations from Plan
+
+None. Implementation matched the plan exactly.
+
+## Tests Written
+
+| Test File | Test Cases |
+|-----------|------------|
+| `server/db_wine.test.ts` | No filters → all 4 wines; single winery filter; multiple wineries (OR semantics); location filter by wine locationId; location filter by winery locationId (Pennsylvania); ancestor expansion (USA); label text search; winery name text search; varietal name text search; winery+location AND semantics; winery+search AND semantics; varietal attachment |

--- a/client/src/pages/ManageWinePage.tsx
+++ b/client/src/pages/ManageWinePage.tsx
@@ -1,16 +1,19 @@
 import { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Plus, Trash2, Edit2 } from "lucide-react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Plus, Trash2, Edit2, Filter, X } from "lucide-react";
 import { toast } from "sonner";
 import { DeleteConfirmDialog } from "@/components/ui/delete-confirm-dialog";
 import { Label } from "@/components/ui/label";
 import { SearchableSelect, SearchableSelectOption } from "@/components/ui/searchable-select";
 import { MultiSelect, MultiSelectOption } from "@/components/ui/multi-select";
+import { WineFilterControls } from "@/components/WineFilterControls";
 
 
 export default function ManageWinePage() {
@@ -18,6 +21,10 @@ export default function ManageWinePage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [wineToDelete, setWineToDelete] = useState<{ id: number; label: string } | null>(null);
+  const [selectedWineries, setSelectedWineries] = useState<string[]>([]);
+  const [selectedLocations, setSelectedLocations] = useState<string[]>([]);
+  const [textSearch, setTextSearch] = useState("");
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [formData, setFormData] = useState({
     label: "",
     wineryId: "",
@@ -29,13 +36,28 @@ export default function ManageWinePage() {
     varietalIds: [] as string[],
   });
 
-  const { data: wines, isLoading, refetch } = trpc.wine.list.useQuery();
+  const { data: wines, isLoading, refetch } = trpc.wine.list.useQuery({
+    wineryIds: selectedWineries.map(id => parseInt(id, 10)),
+    locationIds: selectedLocations.map(id => parseInt(id, 10)),
+    search: textSearch.trim() || undefined,
+  });
   const { data: wineries } = trpc.winery.list.useQuery();
   const { data: varietals } = trpc.varietal.list.useQuery();
   const { data: locations } = trpc.location.listWithPaths.useQuery();
   const createMutation = trpc.wine.create.useMutation();
   const updateMutation = trpc.wine.update.useMutation();
   const deleteMutation = trpc.wine.delete.useMutation();
+
+  const hasActiveFilters =
+    selectedWineries.length > 0 || selectedLocations.length > 0 || textSearch.trim().length > 0;
+  const activeFilterCount =
+    selectedWineries.length + selectedLocations.length + (textSearch.trim() ? 1 : 0);
+
+  const handleClearFilters = () => {
+    setSelectedWineries([]);
+    setSelectedLocations([]);
+    setTextSearch("");
+  };
 
   const wineryOptions: SearchableSelectOption[] =
     wineries?.map((w: any) => ({
@@ -132,7 +154,24 @@ export default function ManageWinePage() {
     <div className="space-y-4">
       <div className="flex justify-between items-center">
         <h2 className="text-xl font-bold">Wines</h2>
-        <Dialog open={open} onOpenChange={setOpen}>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsFilterOpen(true)}
+            className="md:hidden relative"
+          >
+            <Filter className="w-4 h-4" />
+            {activeFilterCount > 0 && (
+              <Badge
+                variant="destructive"
+                className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-xs"
+              >
+                {activeFilterCount}
+              </Badge>
+            )}
+          </Button>
+          <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
             <Button
               onClick={() => {
@@ -248,12 +287,83 @@ export default function ManageWinePage() {
             </form>
           </DialogContent>
         </Dialog>
+        </div>
       </div>
+
+      {/* Desktop filter row */}
+      <div className="hidden md:grid md:grid-cols-3 gap-4">
+        <WineFilterControls
+          selectedLocations={selectedLocations}
+          setSelectedLocations={setSelectedLocations}
+          locations={locations ?? []}
+          selectedWineries={selectedWineries}
+          setSelectedWineries={setSelectedWineries}
+          wineries={wineries ?? []}
+        />
+        <div>
+          <label className="text-sm font-medium text-gray-700 mb-2 block">Search</label>
+          <Input
+            placeholder="Label, winery, or varietal..."
+            value={textSearch}
+            onChange={e => setTextSearch(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {/* Active filter badges */}
+      {hasActiveFilters && (
+        <div className="flex items-center gap-2 flex-wrap">
+          {selectedLocations.map(id => {
+            const loc = (locations ?? []).find(l => l.locationId === parseInt(id, 10));
+            return loc ? (
+              <Badge
+                key={`loc-${id}`}
+                variant="secondary"
+                className="cursor-pointer"
+                onClick={() => setSelectedLocations(selectedLocations.filter(x => x !== id))}
+              >
+                {loc.fullPath}<X className="w-3 h-3 ml-1" />
+              </Badge>
+            ) : null;
+          })}
+          {selectedWineries.map(id => {
+            const w = (wineries ?? []).find(w => w.wineryId === parseInt(id, 10));
+            return w ? (
+              <Badge
+                key={`winery-${id}`}
+                variant="secondary"
+                className="cursor-pointer"
+                onClick={() => setSelectedWineries(selectedWineries.filter(x => x !== id))}
+              >
+                {w.name}<X className="w-3 h-3 ml-1" />
+              </Badge>
+            ) : null;
+          })}
+          {textSearch.trim() && (
+            <Badge
+              variant="secondary"
+              className="cursor-pointer"
+              onClick={() => setTextSearch("")}
+            >
+              "{textSearch}"<X className="w-3 h-3 ml-1" />
+            </Badge>
+          )}
+          <Button variant="ghost" size="sm" onClick={handleClearFilters}>
+            Clear All
+          </Button>
+        </div>
+      )}
+
 
       {isLoading ? (
         <div className="text-center py-8">Loading...</div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {!isLoading && wines?.length === 0 && (
+            <p className="col-span-full text-center py-8 text-gray-500">
+              {hasActiveFilters ? "No wines match your filters." : "No wines found."}
+            </p>
+          )}
           {wines?.map((wine: any) => (
             <Card key={wine.wineId}>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -312,6 +422,38 @@ export default function ManageWinePage() {
         title="Delete Wine"
         description={`Are you sure you want to delete "${wineToDelete?.label}"? This action cannot be undone.`}
       />
+
+      {/* Mobile filter Sheet */}
+      <Sheet open={isFilterOpen} onOpenChange={setIsFilterOpen} modal={false}>
+        <SheetContent side="bottom" className="h-[85vh]">
+          <SheetHeader>
+            <SheetTitle>Filter Wines</SheetTitle>
+          </SheetHeader>
+          <div className="space-y-4 mt-6">
+            <WineFilterControls
+              selectedLocations={selectedLocations}
+              setSelectedLocations={setSelectedLocations}
+              locations={locations ?? []}
+              selectedWineries={selectedWineries}
+              setSelectedWineries={setSelectedWineries}
+              wineries={wineries ?? []}
+            />
+            <div>
+              <label className="text-sm font-medium text-gray-700 mb-2 block">Search</label>
+              <Input
+                placeholder="Label, winery, or varietal..."
+                value={textSearch}
+                onChange={e => setTextSearch(e.target.value)}
+              />
+            </div>
+            {hasActiveFilters && (
+              <Button variant="outline" onClick={handleClearFilters} className="w-full">
+                Clear All Filters
+              </Button>
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/server/db_wine.test.ts
+++ b/server/db_wine.test.ts
@@ -1,6 +1,104 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { getAvailableWinesFiltered, getAvailableLocations } from "./db_wine";
+import { getAllWines, getAvailableWinesFiltered, getAvailableLocations } from "./db_wine";
 import { seedWineDatabase, clearDatabase } from "./test-utils";
+
+describe("getAllWines — curator filters", () => {
+  let seedData: Awaited<ReturnType<typeof seedWineDatabase>>;
+
+  beforeAll(async () => {
+    seedData = await seedWineDatabase();
+  });
+
+  afterAll(async () => {
+    await clearDatabase();
+  });
+
+  it("returns all wines including out-of-stock when no filters given", async () => {
+    const wines = await getAllWines();
+    expect(wines).toHaveLength(4);
+    const labels = wines.map(w => w.label).sort();
+    expect(labels).toEqual(["Napa Cab", "Out of Stock Wine", "R5 Cab", "R5 Chardonnay"]);
+  });
+
+  it("winery filter — single winery returns only that winery's wines", async () => {
+    const wines = await getAllWines({ wineryIds: [seedData.wineries.r5.wineryId] });
+    expect(wines).toHaveLength(3);
+    const labels = wines.map(w => w.label).sort();
+    expect(labels).toEqual(["Out of Stock Wine", "R5 Cab", "R5 Chardonnay"]);
+  });
+
+  it("winery filter — multiple wineries use OR semantics within the dimension", async () => {
+    const wines = await getAllWines({
+      wineryIds: [seedData.wineries.r5.wineryId, seedData.wineries.napaWinery.wineryId],
+    });
+    expect(wines).toHaveLength(4);
+  });
+
+  it("location filter — California matches wines by their own locationId", async () => {
+    const wines = await getAllWines({ locationIds: [seedData.locations.california.locationId] });
+    expect(wines).toHaveLength(4);
+  });
+
+  it("location filter — Pennsylvania matches R5 wines via winery location", async () => {
+    const wines = await getAllWines({ locationIds: [seedData.locations.pa.locationId] });
+    expect(wines).toHaveLength(3);
+    const labels = wines.map(w => w.label).sort();
+    expect(labels).toEqual(["Out of Stock Wine", "R5 Cab", "R5 Chardonnay"]);
+  });
+
+  it("location filter — USA ancestor expansion returns all wines", async () => {
+    const wines = await getAllWines({ locationIds: [seedData.locations.usa.locationId] });
+    expect(wines).toHaveLength(4);
+  });
+
+  it("text search — matches wine label (case-insensitive)", async () => {
+    const wines = await getAllWines({ search: "napa" });
+    expect(wines).toHaveLength(1);
+    expect(wines[0].label).toBe("Napa Cab");
+  });
+
+  it("text search — matches winery name", async () => {
+    const wines = await getAllWines({ search: "R5" });
+    expect(wines).toHaveLength(3);
+    const labels = wines.map(w => w.label).sort();
+    expect(labels).toEqual(["Out of Stock Wine", "R5 Cab", "R5 Chardonnay"]);
+  });
+
+  it("text search — matches varietal name", async () => {
+    // 'Cabernet' appears only in the varietal name, not in any label or winery name
+    const wines = await getAllWines({ search: "Cabernet" });
+    expect(wines).toHaveLength(2);
+    const labels = wines.map(w => w.label).sort();
+    expect(labels).toEqual(["Napa Cab", "R5 Cab"]);
+  });
+
+  it("winery + location filters use AND semantics across dimensions", async () => {
+    // R5 wines match Pennsylvania; Napa winery does not → 0 results
+    const wines = await getAllWines({
+      wineryIds: [seedData.wineries.napaWinery.wineryId],
+      locationIds: [seedData.locations.pa.locationId],
+    });
+    expect(wines).toHaveLength(0);
+  });
+
+  it("winery + text search use AND semantics across dimensions", async () => {
+    // R5 winery AND search 'cab' → only R5 Cab
+    const wines = await getAllWines({
+      wineryIds: [seedData.wineries.r5.wineryId],
+      search: "cab",
+    });
+    expect(wines).toHaveLength(1);
+    expect(wines[0].label).toBe("R5 Cab");
+  });
+
+  it("attaches varietals to returned wines", async () => {
+    const wines = await getAllWines({ wineryIds: [seedData.wineries.r5.wineryId] });
+    const cab = wines.find(w => w.label === "R5 Cab");
+    expect(cab).toBeDefined();
+    expect(cab!.varietals).toHaveLength(1);
+    expect(cab!.varietals[0].name).toBe("Cabernet Sauvignon");
+  });
+});
 
 describe("Wine DB — winery filter and dual-location matching", () => {
   let seedData: Awaited<ReturnType<typeof seedWineDatabase>>;

--- a/server/db_wine.ts
+++ b/server/db_wine.ts
@@ -1,4 +1,4 @@
-import { eq, sql, or, gt, inArray, and } from "drizzle-orm";
+import { eq, sql, or, gt, inArray, and, ilike } from "drizzle-orm";
 import { getDb } from "./db";
 import {
   winery,
@@ -168,33 +168,127 @@ export async function deleteLocation(id: number) {
 // Wine CRUD
 // ============================================================================
 
-export async function getAllWines() {
+export async function getAllWines(filters?: {
+  wineryIds?: number[];
+  locationIds?: number[];
+  search?: string;
+}) {
   const db = await getDb();
   if (!db) return [];
-  
-  // Get wines with their related data
-  const wines = await db
-    .select({
-      wineId: wine.wineId,
-      label: wine.label,
-      vintage: wine.vintage,
-      refrigerated: wine.refrigerated,
-      cellared: wine.cellared,
-      description: wine.description,
-      wineryId: wine.wineryId,
-      locationId: wine.locationId,
-      wineryName: winery.name,
-      locationName: location.name,
-    })
-    .from(wine)
-    .leftJoin(winery, eq(wine.wineryId, winery.wineryId))
-    .leftJoin(location, eq(wine.locationId, location.locationId))
-    .orderBy(wine.label);
-  
-  // Get varietals for each wine
+
+  const { wineryIds, locationIds, search } = filters ?? {};
+  const searchTerm = search?.trim();
+
+  let wines: Array<{
+    wineId: number;
+    label: string;
+    vintage: number | null;
+    refrigerated: number;
+    cellared: number;
+    description: string | null;
+    wineryId: number | null;
+    locationId: number | null;
+    wineryName: string | null;
+    locationName: string | null;
+  }>;
+
+  if (locationIds && locationIds.length > 0) {
+    // Recursive CTE to expand selected location IDs to all descendants.
+    // A wine matches if its own locationId OR its winery's locationId is in the tree.
+    const locationIdList = locationIds.join(", ");
+    const wineryClause = wineryIds?.length
+      ? sql.raw(`AND w.winery_id IN (${wineryIds.join(", ")})`)
+      : sql.raw("");
+    const result = await db.execute(sql`
+      WITH RECURSIVE location_tree AS (
+        SELECT location_id
+        FROM location
+        WHERE location_id IN (${sql.raw(locationIdList)})
+        UNION ALL
+        SELECT l.location_id
+        FROM location l
+        INNER JOIN location_tree lt ON l.parent_id = lt.location_id
+      )
+      SELECT
+        w.wine_id       AS "wineId",
+        w.label,
+        w.vintage,
+        w.refrigerated,
+        w.cellared,
+        w.description,
+        w.winery_id     AS "wineryId",
+        w.location_id   AS "locationId",
+        wr.name         AS "wineryName",
+        l.name          AS "locationName"
+      FROM wine w
+      LEFT JOIN winery wr ON w.winery_id = wr.winery_id
+      LEFT JOIN location l  ON w.location_id = l.location_id
+      WHERE (
+        w.location_id IN (SELECT location_id FROM location_tree)
+        OR wr.location_id IN (SELECT location_id FROM location_tree)
+      )
+      ${wineryClause}
+      ${searchTerm
+        ? sql`AND (
+            w.label ILIKE ${'%' + searchTerm + '%'}
+            OR wr.name ILIKE ${'%' + searchTerm + '%'}
+            OR EXISTS (
+              SELECT 1 FROM wine_varietal wv
+              JOIN varietal v ON wv.varietal_id = v.varietal_id
+              WHERE wv.wine_id = w.wine_id AND v.name ILIKE ${'%' + searchTerm + '%'}
+            )
+          )`
+        : sql``}
+      ORDER BY w.label
+    `);
+    wines = result.rows as typeof wines;
+  } else {
+    // No location filter — use Drizzle ORM.
+    // Each dimension is ANDed together; multiple values within a dimension are ORed.
+    const conditions = [];
+
+    if (wineryIds?.length) {
+      conditions.push(inArray(wine.wineryId, wineryIds));
+    }
+
+    if (searchTerm) {
+      conditions.push(
+        or(
+          ilike(wine.label, `%${searchTerm}%`),
+          ilike(winery.name, `%${searchTerm}%`),
+          sql`EXISTS (
+            SELECT 1 FROM wine_varietal wv
+            JOIN varietal v ON wv.varietal_id = v.varietal_id
+            WHERE wv.wine_id = ${wine.wineId} AND v.name ILIKE ${'%' + searchTerm + '%'}
+          )`
+        )!
+      );
+    }
+
+    wines = await db
+      .select({
+        wineId: wine.wineId,
+        label: wine.label,
+        vintage: wine.vintage,
+        refrigerated: wine.refrigerated,
+        cellared: wine.cellared,
+        description: wine.description,
+        wineryId: wine.wineryId,
+        locationId: wine.locationId,
+        wineryName: winery.name,
+        locationName: location.name,
+      })
+      .from(wine)
+      .leftJoin(winery, eq(wine.wineryId, winery.wineryId))
+      .leftJoin(location, eq(wine.locationId, location.locationId))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(wine.label);
+  }
+
+  // Attach varietals for each wine
   const winesWithVarietals = await Promise.all(
     wines.map(async (w) => {
-      const varietals = await db
+      const varietals = await db!
         .select({
           varietalId: varietal.varietalId,
           name: varietal.name,
@@ -202,14 +296,10 @@ export async function getAllWines() {
         .from(wineVarietal)
         .innerJoin(varietal, eq(wineVarietal.varietalId, varietal.varietalId))
         .where(eq(wineVarietal.wineId, w.wineId));
-      
-      return {
-        ...w,
-        varietals,
-      };
+      return { ...w, varietals };
     })
   );
-  
+
   return winesWithVarietals;
 }
 

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -362,7 +362,15 @@ export const appRouter = router({
   }),
 
   wine: router({
-    list: publicProcedure.query(() => dbWine.getAllWines()),
+    list: publicProcedure
+      .input(
+        z.object({
+          wineryIds: z.array(z.number()).optional(),
+          locationIds: z.array(z.number()).optional(),
+          search: z.string().optional(),
+        })
+      )
+      .query(({ input }) => dbWine.getAllWines(input)),
     listAvailable: publicProcedure
       .input(
         z.object({


### PR DESCRIPTION
## Summary

- Updated `getAllWines()` in `server/db_wine.ts` to accept `wineryIds`, `locationIds`, and `search` filter params, applied at the database level — uses a recursive CTE for location hierarchy (matching the `getAvailableWinesFiltered` pattern) and `ilike` for text search across label, winery name, and varietal name
- Added input schema to the `wine.list` tRPC procedure in `server/routers.ts`
- Added winery, location, and text search filter UI to `ManageWinePage.tsx`: desktop 3-column grid, mobile Sheet drawer, and dismissible active-filter badges

**Filter semantics**: multiple values within one dimension use OR (e.g. two wineries → wines from either); multiple dimensions use AND (e.g. winery + location → must match both).

## Test plan

- [ ] Navigate to the Manage tab → Wines as a curator
- [ ] Select a winery in the Winery filter — verify only that winery's wines are shown
- [ ] Select two wineries — verify wines from either winery are shown (OR)
- [ ] Select a location — verify wines where the wine's location or the winery's location is within the hierarchy are shown
- [ ] Type in the Search field — verify filtering by label, winery name, and varietal name works (case-insensitive)
- [ ] Combine winery + location filters — verify only wines satisfying both are shown (AND)
- [ ] Click a filter badge × — verify that filter is cleared and list updates
- [ ] Click Clear All — verify all filters reset
- [ ] On mobile viewport — verify Filter button appears, Sheet opens with all controls

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)