### PR TITLE
feat: filter winery dropdown to available stock (#113)

### DIFF
--- a/client/src/pages/WinePage.tsx
+++ b/client/src/pages/WinePage.tsx
@@ -77,8 +77,8 @@ export default function WinePage() {
   // Fetch only locations that have available wines (for filter options)
   const { data: locations = [] } = trpc.location.listAvailable.useQuery();
 
-  // Fetch all wineries (for filter options)
-  const { data: wineries = [] } = trpc.winery.list.useQuery();
+  // Fetch only wineries that have available wines (for filter options)
+  const { data: wineries = [] } = trpc.winery.listAvailable.useQuery();
 
   const handleClearFilters = () => {
     setSelectedLocations([]);

--- a/server/db_wine.test.ts
+++ b/server/db_wine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { getAllWines, getAvailableWinesFiltered, getAvailableLocations } from "./db_wine";
+import { getAllWines, getAvailableWinesFiltered, getAvailableLocations, getAvailableWineries } from "./db_wine";
 import { seedWineDatabase, clearDatabase } from "./test-utils";
 
 describe("getAllWines — curator filters", () => {
@@ -205,6 +205,32 @@ describe("Wine DB — winery filter and dual-location matching", () => {
       const locations = await getAvailableLocations();
       const names = locations.map((l) => l.name);
       expect(names).not.toContain("Chester County");
+    });
+  });
+
+  describe("getAvailableWineries", () => {
+    it("returns R5 Winery (has in-stock wines)", async () => {
+      const wineries = await getAvailableWineries();
+      const names = wineries.map((w) => w.name);
+      expect(names).toContain("R5 Winery");
+    });
+
+    it("returns Napa Valley Winery (has in-stock wines)", async () => {
+      const wineries = await getAvailableWineries();
+      const names = wineries.map((w) => w.name);
+      expect(names).toContain("Napa Valley Winery");
+    });
+
+    it("does not return Empty Winery (no wines)", async () => {
+      const wineries = await getAvailableWineries();
+      const names = wineries.map((w) => w.name);
+      expect(names).not.toContain("Empty Winery");
+    });
+
+    it("returns wineries ordered by name", async () => {
+      const wineries = await getAvailableWineries();
+      const names = wineries.map((w) => w.name);
+      expect(names).toEqual([...names].sort());
     });
   });
 });

--- a/server/db_wine.ts
+++ b/server/db_wine.ts
@@ -22,6 +22,21 @@ export async function getAllWineries() {
   return db.select().from(winery).orderBy(winery.name);
 }
 
+export async function getAvailableWineries() {
+  const db = await getDb();
+  if (!db) return [];
+
+  const rows = await db
+    .selectDistinct({ wineryId: wine.wineryId })
+    .from(wine)
+    .where(or(gt(wine.refrigerated, 0), gt(wine.cellared, 0)));
+
+  const ids = rows.map(r => r.wineryId).filter((id): id is number => id !== null);
+  if (ids.length === 0) return [];
+
+  return db.select().from(winery).where(inArray(winery.wineryId, ids)).orderBy(winery.name);
+}
+
 export async function getWineryById(id: number) {
   const db = await getDb();
   if (!db) return null;

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -276,6 +276,7 @@ export const appRouter = router({
   // Wine management routes
   winery: router({
     list: publicProcedure.query(() => dbWine.getAllWineries()),
+    listAvailable: publicProcedure.query(() => dbWine.getAvailableWineries()),
     getById: publicProcedure
       .input(z.object({ id: z.number() }))
       .query(({ input }) => dbWine.getWineryById(input.id)),

--- a/server/test-utils.ts
+++ b/server/test-utils.ts
@@ -230,10 +230,12 @@ export async function seedWineDatabase() {
     .values([
       { name: "R5 Winery", locationId: pa.locationId },
       { name: "Napa Valley Winery", locationId: california.locationId },
+      { name: "Empty Winery" },
     ])
     .returning();
   const r5 = wineries[0];
   const napaWinery = wineries[1];
+  const emptyWinery = wineries[2];
 
   const varietals = await db
     .insert(varietal)
@@ -267,7 +269,7 @@ export async function seedWineDatabase() {
 
   return {
     locations: { usa, pa, california, chesterCounty },
-    wineries: { r5, napaWinery },
+    wineries: { r5, napaWinery, emptyWinery },
     varietals: { cab, chard },
     wines: { r5Cab, r5Chard, napaCab, outOfStock },
   };


### PR DESCRIPTION
## Summary

- Added `getAvailableWineries()` DB function that returns only wineries with at least one wine in stock (`refrigerated > 0 OR cellared > 0`)
- Added `winery.listAvailable` tRPC endpoint (mirrors existing `location.listAvailable` pattern)
- Updated wine browse page to use `winery.listAvailable` instead of `winery.list`
- Added `Empty Winery` test seed entry and tests covering the positive and negative cases

## Test plan

- [ ] All 90 tests pass (`npm test`)
- [ ] Winery dropdown on the wine browse page only shows wineries that have wines in stock
- [ ] Selecting any winery from the dropdown returns at least one wine result

🤖 Generated with [Claude Code](https://claude.com/claude-code)