### PR TITLE
Beer Inventory Mode — list with inline status editing

### DIFF
--- a/.agents/plans/completed/beer-inventory-mode.plan.md
+++ b/.agents/plans/completed/beer-inventory-mode.plan.md
@@ -1,0 +1,215 @@
+# Plan: Beer Inventory Mode — List with Inline Status Editing
+
+## Summary
+
+Add a curator-only `/beer/inventory` route and `BeerInventory.tsx` page that lists every currently-available beer (`beer.listAvailable`, already server-side filtered to `on_tap`/`bottle_can`) with a per-row status control for inline editing. Changing a row's status calls `beer.update` directly (no dialog, no route change); on success the row is removed from the TanStack Query cache in place via `utils.beer.listAvailable.setData`, so the list re-renders without a refetch-triggered remount and scroll position is preserved. No backend changes are needed — both `beer.listAvailable` and `beer.update` already exist and support this exactly as required.
+
+## User Story
+
+As a curator
+I want to see a list of currently-available beers and change a beer's status inline
+So that I can reconcile physical stock quickly without leaving the list
+
+## Metadata
+
+| Field            | Value                                                             |
+| ---------------- | ----------------------------------------------------------------- |
+| Type             | NEW_CAPABILITY                                                    |
+| Complexity       | LOW                                                               |
+| Systems Affected | client routing (`App.tsx`), new client page (`BeerInventory.tsx`) |
+| GitHub Issue     | 126                                                               |
+
+---
+
+## Patterns to Follow
+
+### Route registration
+
+```typescript
+// SOURCE: client/src/App.tsx:24
+<Route path="/beer-management" component={BeerManagement} />
+```
+
+### Curator/admin guard (redirect pattern)
+
+```typescript
+// SOURCE: client/src/pages/BeerManagement.tsx:18,23-30,54-56
+const { data: user, isLoading } = trpc.auth.me.useQuery();
+...
+useEffect(() => {
+  if (
+    !isLoading &&
+    (!user || (user.role !== "curator" && user.role !== "admin"))
+  ) {
+    setLocation("/browser");
+  }
+}, [user, isLoading, setLocation]);
+...
+if (!user || (user.role !== "curator" && user.role !== "admin")) {
+  return null;
+}
+```
+
+### Status values (currently a plain `<select>`, this plan upgrades to shadcn `Select` for per-row use)
+
+```typescript
+// SOURCE: client/src/pages/BeerPage.tsx:228-238
+<select
+  value={formData.status}
+  onChange={(e) => setFormData({ ...formData, status: e.target.value as "on_tap" | "bottle_can" | "out" })}
+  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+>
+  <option value="on_tap">On Tap</option>
+  <option value="bottle_can">Bottle/Can</option>
+  <option value="out">Out</option>
+</select>
+```
+
+### shadcn Select component (target pattern for per-row control)
+
+```typescript
+// SOURCE: client/src/pages/LocationPage.tsx:11-17,151-163
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+<Select value={formData.type} onValueChange={(value: any) => setFormData({ ...formData, type: value })}>
+  <SelectTrigger>
+    <SelectValue />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="country">Country</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+### tRPC query/mutation + cache utils
+
+```typescript
+// SOURCE: server/routers.ts:192,209-225 (existing endpoints — no changes needed)
+listAvailable: publicProcedure.query(() => db.getAllAvailableBeers()),
+update: curatorProcedure
+  .input(z.object({ id: z.number(), status: z.enum(["on_tap", "bottle_can", "out"]).optional(), /* ...other optional fields */ }))
+  .mutation(({ input }) => {
+    const { id, ...data } = input;
+    return db.updateBeer(id, data);
+  }),
+```
+
+```typescript
+// SOURCE: client/src/pages/BeerManagement.tsx:20 (utils pattern; setData usage is new to this codebase but is standard @trpc/react-query v11 API)
+const utils = trpc.useUtils();
+```
+
+### Types
+
+```typescript
+// SOURCE: drizzle/schema.ts:97 (re-exported via shared/types.ts:6)
+export type Beer = typeof beer.$inferSelect;
+```
+
+---
+
+## Files to Change
+
+| File                                 | Action | Purpose                                                         |
+| ------------------------------------ | ------ | --------------------------------------------------------------- |
+| `client/src/pages/BeerInventory.tsx` | CREATE | New curator-only inventory list page with inline status editing |
+| `client/src/App.tsx`                 | UPDATE | Register `/beer/inventory` route                                |
+
+No server changes: `beer.listAvailable` (`server/routers.ts:192`) and `beer.update` (`server/routers.ts:209-225`) already provide exactly the data/mutation shape this page needs.
+
+---
+
+## Tasks
+
+### Task 1: Create `BeerInventory.tsx`
+
+- **File**: `client/src/pages/BeerInventory.tsx`
+- **Action**: CREATE
+- **Implement**:
+  - Curator/admin guard identical in behavior to `BeerManagement.tsx:18,23-30,54-56` (redirect to `/browser` if not curator/admin; render `null` while redirecting; show a loading state while `trpc.auth.me.useQuery()` is pending, mirroring `BeerManagement.tsx:43-52`).
+  - Fetch data with `const { data: beers, isLoading } = trpc.beer.listAvailable.useQuery();`.
+  - `const updateMutation = trpc.beer.update.useMutation();` and `const utils = trpc.useUtils();`.
+  - Render a simple header (title "Beer Inventory", a `Link` back to `/dashboard` using the `Link`/`Button` pattern from `BeerManagement.tsx:63-74` — no need to duplicate the full tab/logout header, this is a focused single-purpose page).
+  - Render each beer as a row (a `Card` per `BeerPage.tsx:358-395`, or a simpler flex row — either is acceptable, but keep it a single-column full-width list, not the `md:grid-cols-2` layout, since this page is optimized for one-handed phone use per the PRD) showing: beer name, and a `Select` (shadcn, from `client/src/components/ui/select.tsx`, per the `LocationPage.tsx:151-163` pattern) bound to the beer's current `status`, with the three `SelectItem`s `on_tap` / `bottle_can` / `out` (labels "On Tap" / "Bottle/Can" / "Out", matching `BeerPage.tsx:234-236`).
+  - Give the `SelectTrigger` a larger touch target than the default (`h-10`) — e.g. `className="h-12 w-40 text-base"` — to satisfy the phone-tap-accuracy acceptance criterion.
+  - On `onValueChange`, call:
+    ```typescript
+    const handleStatusChange = async (beerId: number, status: "on_tap" | "bottle_can" | "out") => {
+      try {
+        await updateMutation.mutateAsync({ id: beerId, status });
+        if (status === "out") {
+          utils.beer.listAvailable.setData(undefined, (old) => old?.filter((b) => b.beerId !== beerId));
+        } else {
+          utils.beer.listAvailable.setData(undefined, (old) =>
+            old?.map((b) => (b.beerId === beerId ? { ...b, status } : b))
+          );
+        }
+        toast.success("Status updated");
+      } catch (error) {
+        toast.error("Error updating status");
+      }
+    };
+    ```
+    This is the key mechanism satisfying the "no jump to top / scroll position preserved" acceptance criterion: it patches the existing query's cached array in place (add/remove/update one item) rather than calling `refetch()` or `invalidate()`, so React only re-renders the changed/removed row instead of unmounting and remounting the whole list.
+  - Empty state: when `beers?.length === 0`, show a centered message ("No beers currently available." ) mirroring `BeerPage.tsx:349-354`.
+  - Loading state: mirror `BeerPage.tsx:347-348` (`isLoading ? <div className="text-center py-8">Loading...</div> : ...`).
+- **Mirror**: `client/src/pages/BeerManagement.tsx:15-56` (guard + loading), `client/src/pages/BeerPage.tsx:228-238,347-397` (status values, list/loading/empty rendering), `client/src/pages/LocationPage.tsx:151-163` (shadcn `Select` usage)
+- **Validate**: `npm run check`
+
+### Task 2: Register the `/beer/inventory` route
+
+- **File**: `client/src/App.tsx`
+- **Action**: UPDATE
+- **Implement**: Add the import and route:
+  ```typescript
+  import BeerInventory from "@/pages/BeerInventory";
+  ```
+  ```typescript
+  <Route path="/beer-management" component={BeerManagement} />
+  <Route path="/beer/inventory" component={BeerInventory} />
+  <Route path="/wine-management" component={WineManagement} />
+  ```
+- **Mirror**: `client/src/App.tsx:9,24` (existing import/route pair for `BeerManagement`)
+- **Validate**: `npm run check`
+
+---
+
+## Validation
+
+```bash
+# Type check
+npm run check
+
+# Format
+npm run format
+
+# Tests (no server logic changed, but run the suite to confirm nothing broke)
+npm test
+```
+
+Manual check (no automated client tests exist in this repo — `server/**/*.test.ts` only):
+
+1. Log in as a `user`-role account (or log out) → navigating to `/beer/inventory` redirects to `/browser`.
+2. Log in as curator/admin → `/beer/inventory` shows only beers with status `on_tap`/`bottle_can`.
+3. Change a beer's status to `on_tap`/`bottle_can` → row stays, status control reflects the new value, no dialog/navigation occurs.
+4. Change a beer's status to `Out` → row disappears from the list; scroll position of the remaining rows is unaffected (test with enough beers to require scrolling).
+5. View at a phone-width viewport (e.g. 375px) → rows and the status `Select` are easily tappable.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Curator/admin sees every beer with status `on_tap` or `bottle_can`, and no others, at `/beer/inventory`
+- [ ] Non-curator (or logged-out) visitors are redirected away from `/beer/inventory`
+- [ ] Changing status inline calls `beer.update` with just the status change — no dialog/modal, no route navigation
+- [ ] Setting status to `Out` removes the row in place with scroll position preserved (no refetch-triggered remount)
+- [ ] Status control is large enough to tap accurately on a phone-width viewport
+- [ ] Type check passes (`npm run check`)
+- [ ] Tests pass (`npm test`)
+- [ ] Follows existing patterns (guard, list/loading/empty states, shadcn `Select`)

--- a/.agents/reports/beer-inventory-mode-report.md
+++ b/.agents/reports/beer-inventory-mode-report.md
@@ -1,0 +1,53 @@
+# Implementation Report
+
+**Plan**: `.agents/plans/beer-inventory-mode.plan.md`
+**Branch**: `126/beer-inventory-mode`
+**Status**: COMPLETE
+
+## Summary
+
+Added a curator-only `/beer/inventory` route (`BeerInventory.tsx`) listing every currently-available beer (`beer.listAvailable`) with an inline shadcn `Select` per row for status editing. Status changes call `beer.update` directly — no dialog, no route navigation — and patch the TanStack Query cache in place (`utils.beer.listAvailable.setData`) instead of refetching, so the row updates or disappears (when set to `Out`) without a full list remount or scroll-position loss. No backend changes were required; both endpoints already existed with the needed shape.
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Create curator-only inventory page with inline status editing | `client/src/pages/BeerInventory.tsx` | ✅ |
+| 2 | Register `/beer/inventory` route | `client/src/App.tsx` | ✅ |
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check (`npm run check`) | ✅ Zero new errors (confirmed identical pre-existing errors on `main` via `git stash` comparison) |
+| Format (`npm run format`) | ⚠️ Ran once; discovered the repo is not currently Prettier-clean and `prettier --write .` reformatted ~160 unrelated tracked files. Reverted all of those via `git checkout -- .` and reapplied only the two intended lines in `App.tsx` by hand. `BeerInventory.tsx` (new/untracked) kept its Prettier formatting from that run since it needed formatting anyway. Did not re-run repo-wide format after that. |
+| Tests (`npm test`) | ✅ 90 passed (90), confirmed again after the revert |
+| Manual E2E (see below) | ✅ |
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `client/src/pages/BeerInventory.tsx` | CREATE | +103 |
+| `client/src/App.tsx` | UPDATE | +2 |
+
+## Deviations from Plan
+
+None. Implementation matches the plan's task specifications, including the `h-12 w-40 text-base` `SelectTrigger` sizing for phone tap targets and the cache-patch-in-place mutation handler.
+
+## Tests Written
+
+No new automated tests: this repo's test suite is server-only (`server/**/*.test.ts`, per `CLAUDE.md`), and this feature required no server changes — both `beer.listAvailable` and `beer.update` already have existing coverage. The plan's validation section calls for manual/E2E verification instead, which was performed (below).
+
+## End-to-End Verification
+
+No browser-automation tool was available in this environment (`agent-browser` CLI referenced by the project's skill is not installed here, and no Playwright/Puppeteer install exists in the repo or system). In its place, the exact HTTP calls the new page makes were exercised directly against a running dev server (`npm run dev`, pointed at the local `beerdb` Postgres instance — the `.env` `DATABASE_URL` there has a stale dbname, `beer_menu` vs. the container's actual `beerdb`, a pre-existing environment issue unrelated to this change and left as-is), using a seeded curator user and seeded beers, then cleaned up afterward:
+
+1. **Curator/admin sees only `on_tap`/`bottle_can` beers** — seeded 4 beers (`on_tap` ×2, `bottle_can` ×1, `out` ×1); `beer.listAvailable` returned exactly the 3 available ones, excluding the `out` beer. ✅
+2. **Non-curator/logged-out is rejected** — called `beer.update` with no session cookie → `403 FORBIDDEN "Access denied. Curator role required."` (the same `curatorProcedure` guard the page's mutation goes through). ✅
+3. **Inline status change → `beer.update` called directly, no dialog/route change** — confirmed by code inspection (`handleStatusChange` calls `updateMutation.mutateAsync({ id, status })` directly from the `Select`'s `onValueChange`, no `Dialog`/`setLocation` involved) and by exercising the same call via curl with a forged curator session cookie (`auth.me` resolved correctly to the seeded curator). ✅
+4. **Setting status to `Out` removes the row** — called `beer.update` on one of the available beers with `status: "out"`; a follow-up `beer.listAvailable` call confirmed it was excluded from the result, matching the client's cache-filter logic which runs in the same case. ✅
+5. **Route resolves** — `GET /beer/inventory` returned `200` with the SPA shell (`<title>Beer Menu</title>`), confirming the wouter route registration in `App.tsx` is wired correctly. ✅
+6. **Touch target sizing** — verified by code inspection: `SelectTrigger` uses `className="h-12 w-40 text-base"` (48px height, above the ~44px minimum recommended tap target), consistent with the plan.
+
+What was **not** independently confirmed due to tooling limits: actual on-screen rendering of the row list, click-driven interaction through the real `Select` UI, and literal scroll-position preservation during a live re-render. These are covered by: (a) the type checker validating the component against the real tRPC/Select types, (b) the cache-patch mechanism (`setData` mutating the existing query's array) being the same mechanism TanStack Query uses to avoid remounting subscribed components, which is the documented, standard way to avoid the refetch-triggered remount this feature is meant to fix, and (c) direct code review against the plan's mirrored patterns.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Login from "@/pages/Login";
 import Home from "@/pages/Home";
 import WinePage from "@/pages/WinePage";
 import BeerManagement from "@/pages/BeerManagement";
+import BeerInventory from "@/pages/BeerInventory";
 import WineManagement from "@/pages/WineManagement";
 import { Route, Switch, Redirect } from "wouter";
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -22,6 +23,7 @@ function Router() {
       <Route path="/login" component={Login} />
       <Route path="/dashboard" component={Dashboard} />
       <Route path="/beer-management" component={BeerManagement} />
+      <Route path="/beer/inventory" component={BeerInventory} />
       <Route path="/wine-management" component={WineManagement} />
       <Route path="/404" component={NotFound} />
       {/* Final fallback route */}

--- a/client/src/pages/BeerInventory.tsx
+++ b/client/src/pages/BeerInventory.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import { Link, useLocation } from "wouter";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Beer } from "lucide-react";
+import { toast } from "sonner";
+
+type BeerStatus = "on_tap" | "bottle_can" | "out";
+
+export default function BeerInventory() {
+  const [, setLocation] = useLocation();
+  const { data: user, isLoading: userLoading } = trpc.auth.me.useQuery();
+  const { data: beers, isLoading: beersLoading } = trpc.beer.listAvailable.useQuery();
+  const updateMutation = trpc.beer.update.useMutation();
+  const utils = trpc.useUtils();
+
+  // Redirect to login if not authenticated or not a curator/admin
+  useEffect(() => {
+    if (!userLoading && (!user || (user.role !== "curator" && user.role !== "admin"))) {
+      setLocation("/browser");
+    }
+  }, [user, userLoading, setLocation]);
+
+  const handleStatusChange = async (beerId: number, status: BeerStatus) => {
+    try {
+      await updateMutation.mutateAsync({ id: beerId, status });
+      if (status === "out") {
+        utils.beer.listAvailable.setData(undefined, (old) => old?.filter((b) => b.beerId !== beerId));
+      } else {
+        utils.beer.listAvailable.setData(undefined, (old) =>
+          old?.map((b) => (b.beerId === beerId ? { ...b, status } : b))
+        );
+      }
+      toast.success("Status updated");
+    } catch (error) {
+      toast.error("Error updating status");
+    }
+  };
+
+  if (userLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <Beer className="w-12 h-12 text-amber-600 mx-auto mb-4 animate-pulse" />
+          <p className="text-gray-600">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user || (user.role !== "curator" && user.role !== "admin")) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200 shadow-sm">
+        <div className="max-w-2xl mx-auto px-4 py-4 flex justify-between items-center">
+          <div className="flex items-center gap-3">
+            <Beer className="w-8 h-8 text-amber-600" />
+            <h1 className="text-2xl font-bold text-gray-900">Beer Inventory</h1>
+          </div>
+          <Link href="/dashboard">
+            <Button variant="outline" size="sm">
+              Back to Dashboard
+            </Button>
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-8 space-y-3">
+        {beersLoading ? (
+          <div className="text-center py-8">Loading...</div>
+        ) : beers?.length === 0 ? (
+          <div className="text-center py-8 text-gray-500">No beers currently available.</div>
+        ) : (
+          beers?.map((beer) => (
+            <Card key={beer.beerId}>
+              <CardContent className="flex items-center justify-between gap-4 py-4">
+                <span className="text-lg font-medium">{beer.name}</span>
+                <Select
+                  value={beer.status ?? "out"}
+                  onValueChange={(value: BeerStatus) => handleStatusChange(beer.beerId, value)}
+                >
+                  <SelectTrigger className="h-12 w-40 text-base">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="on_tap">On Tap</SelectItem>
+                    <SelectItem value="bottle_can">Bottle/Can</SelectItem>
+                    <SelectItem value="out">Out</SelectItem>
+                  </SelectContent>
+                </Select>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a curator-only `/beer/inventory` route and `BeerInventory.tsx` page listing every currently-available beer (`beer.listAvailable`), each with an inline `Select` for status editing.
- Status changes call `beer.update` directly (no dialog, no route navigation) and patch the TanStack Query cache in place, so the list updates without a refetch-triggered remount — preserving scroll position when a beer's status changes to `Out` and it drops off the list.
- No backend changes needed; both `beer.listAvailable` and `beer.update` already supported this.

## Test plan
- [x] `npm run check` — no new type errors
- [x] `npm test` — 90/90 passing
- [x] Manual verification against a running dev server with a seeded curator user and beers (see `.agents/reports/beer-inventory-mode-report.md` for full detail): curator/admin sees only `on_tap`/`bottle_can` beers, non-curator is rejected with 403, setting a beer to `Out` removes it from `beer.listAvailable`, and the `/beer/inventory` route resolves correctly.
- [ ] Browser-based click-through verification wasn't possible in this environment (no browser automation tool available) — recommend a quick manual check in a real browser before merge, especially for the "no scroll jump" behavior.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)