### PR TITLE
feat: add confirmed-present action to Beer Inventory Mode

### DIFF
--- a/.agents/plans/completed/beer-inventory-confirm-present.plan.md
+++ b/.agents/plans/completed/beer-inventory-confirm-present.plan.md
@@ -1,0 +1,189 @@
+# Plan: Beer Inventory Mode — Confirmed Present Action
+
+## Summary
+
+Add a "confirmed present" button to each row in `client/src/pages/BeerInventory.tsx`, letting a curator mark a beer as reviewed without editing any data. Confirmation is tracked purely in local component state (`useState<Set<number>>`) and is used to filter the rendered list — no new tRPC procedure, no DB column, no persistence. Because it's a separate filter layered on top of the existing `beer.listAvailable` cache (which the status-edit path already mutates via `utils.beer.listAvailable.setData`), the confirm path and the edit path naturally don't interfere: one hides rows via local state, the other removes rows from the query cache. A small count badge in the header shows how many items remain unconfirmed.
+
+## User Story
+
+As a curator
+I want to mark a beer as "confirmed present" without changing any data
+So that I can quickly clear items that are correct as-is and see what's left to review
+
+## Metadata
+
+| Field            | Value                             |
+| ---------------- | --------------------------------- |
+| Type             | ENHANCEMENT                       |
+| Complexity       | LOW                               |
+| Systems Affected | client only (`BeerInventory.tsx`) |
+| GitHub Issue     | 127                               |
+
+---
+
+## Patterns to Follow
+
+### Existing status-edit removal path (must not be duplicated/broken)
+
+```typescript
+// SOURCE: client/src/pages/BeerInventory.tsx:26-40
+const handleStatusChange = async (beerId: number, status: BeerStatus) => {
+  try {
+    await updateMutation.mutateAsync({ id: beerId, status });
+    if (status === "out") {
+      utils.beer.listAvailable.setData(undefined, (old) => old?.filter((b) => b.beerId !== beerId));
+    } else {
+      utils.beer.listAvailable.setData(undefined, (old) =>
+        old?.map((b) => (b.beerId === beerId ? { ...b, status } : b))
+      );
+    }
+    toast.success("Status updated");
+  } catch (error) {
+    toast.error("Error updating status");
+  }
+};
+```
+
+This stays untouched. The confirm action must not call `updateMutation` or touch the query cache — it is a purely local, additive filter.
+
+### Icon-only row button (closest structural analog — ghost variant, size sm, icon-only)
+
+```tsx
+// SOURCE: client/src/pages/LocationPage.tsx:207-216
+<Button variant="ghost" size="sm" onClick={() => handleEdit(location)}>
+  <Edit2 className="w-4 h-4" />
+</Button>
+```
+
+No existing "confirm"/checkmark button exists anywhere in the app; `Check` from `lucide-react` is otherwise only used inside `components/ui/searchable-select.tsx` and `multi-select.tsx` for selected-option indicators — this plan introduces it fresh as a row action, following the same import style (`import { Beer, Check } from "lucide-react";`).
+
+### Count badge (no "N remaining" pattern exists yet — reuse the generic `Badge` primitive)
+
+```tsx
+// SOURCE: client/src/components/ui/badge.tsx:28-44 (component signature)
+import { Badge } from "@/components/ui/badge";
+<Badge variant="secondary">{n}</Badge>;
+```
+
+`BeerPage.tsx:262-268` shows the closest existing usage (a count badge next to a header control), but for _filters_, not list progress — no direct copy applies beyond "use `<Badge>` for a small count pill."
+
+### Guard / loading / empty-state structure (unchanged, just re-point at the filtered list)
+
+```typescript
+// SOURCE: client/src/pages/BeerInventory.tsx:74-99 (current render block)
+{beersLoading ? (
+  <div className="text-center py-8">Loading...</div>
+) : beers?.length === 0 ? (
+  <div className="text-center py-8 text-gray-500">No beers currently available.</div>
+) : (
+  beers?.map((beer) => ( ... ))
+)}
+```
+
+---
+
+## Files to Change
+
+| File                                 | Action | Purpose                                                                                            |
+| ------------------------------------ | ------ | -------------------------------------------------------------------------------------------------- |
+| `client/src/pages/BeerInventory.tsx` | UPDATE | Add session-only confirm state, confirm button per row, filter rendered list, show remaining count |
+
+No other files change. No server, schema, or route changes — this is entirely contained in the existing page component.
+
+---
+
+## Tasks
+
+### Task 1: Add confirmed-IDs state and derive the visible list
+
+- **File**: `client/src/pages/BeerInventory.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Change the React import to include `useState`: `import { useEffect, useState } from "react";`
+  - Add local state directly below the existing hooks (after `const utils = trpc.useUtils();`):
+    ```typescript
+    const [confirmedIds, setConfirmedIds] = useState<Set<number>>(new Set());
+    ```
+  - Derive the rendered list from both the query cache and the confirmed set:
+    ```typescript
+    const visibleBeers = beers?.filter((b) => !confirmedIds.has(b.beerId));
+    ```
+  - Add a confirm handler near `handleStatusChange`:
+    ```typescript
+    const handleConfirm = (beerId: number) => {
+      setConfirmedIds((prev) => new Set(prev).add(beerId));
+    };
+    ```
+  - This state is intentionally never persisted or reset except on remount (e.g. navigating away and back), which is what makes it "session-only" per the PRD/acceptance criteria — no additional reset logic is needed.
+- **Mirror**: existing hook block at `client/src/pages/BeerInventory.tsx:13-17`
+- **Validate**: `npm run check`
+
+### Task 2: Render the confirm button per row and switch rendering to `visibleBeers`
+
+- **File**: `client/src/pages/BeerInventory.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add `Check` to the existing `lucide-react` import: `import { Beer, Check } from "lucide-react";`
+  - Replace the `beers?.length === 0` / `beers?.map(...)` block (lines 76-99) to use `visibleBeers` instead of `beers` in both the empty-state check and the `.map`.
+  - Inside each row's `CardContent` (currently: beer name + `Select`), add a confirm `Button` after the `Select`:
+    ```tsx
+    <Button variant="ghost" size="icon-sm" onClick={() => handleConfirm(beer.beerId)} aria-label="Confirm present">
+      <Check className="w-4 h-4" />
+    </Button>
+    ```
+  - Import `Button` is already present (`client/src/pages/BeerInventory.tsx:4`) — no new import needed for it.
+  - Do not call `updateMutation` or `utils.beer.listAvailable.setData` from this handler — confirming must never trigger a `beer.update` mutation (per acceptance criteria).
+- **Mirror**: `client/src/pages/LocationPage.tsx:207-216` (ghost icon button in a row), `client/src/components/ui/button.tsx:27-29` (`icon-sm` size variant)
+- **Validate**: `npm run check`
+
+### Task 3: Show a remaining-count indicator in the header
+
+- **File**: `client/src/pages/BeerInventory.tsx`
+- **Action**: UPDATE
+- **Implement**:
+  - Add `import { Badge } from "@/components/ui/badge";`
+  - In the header block (next to the "Beer Inventory" `h1`, inside the existing `flex items-center gap-3` div), add:
+    ```tsx
+    {
+      !beersLoading && <Badge variant="secondary">{visibleBeers?.length ?? 0} remaining</Badge>;
+    }
+    ```
+  - This is a nice-to-have per the acceptance criteria ("visible way to tell how many remain") — keep it to this one badge, no separate progress bar or "X of Y" fraction, since the total (Y) isn't otherwise displayed and computing/showing it isn't required.
+- **Mirror**: `client/src/pages/BeerPage.tsx:262-268` (badge placed next to a header control)
+- **Validate**: `npm run check`
+
+---
+
+## Validation
+
+```bash
+# Type check
+npm run check
+
+# Format
+npm run format
+
+# Tests (no server logic changes, but confirm nothing broke)
+npm test
+```
+
+Manual check (no automated client tests exist in this repo — `server/**/*.test.ts` only):
+
+1. Navigate to `/beer/inventory` as curator/admin with several available beers listed.
+2. Tap "Confirm" on a row → the row disappears immediately; no toast, no network request (verify in devtools Network tab that no `beer.update` call fires); the remaining-count badge decrements.
+3. Change another row's status via the `Select` (e.g. to "Out") → that row disappears too (existing #126 behavior via cache update), independent of any confirms — confirming one row and editing another don't affect each other's item.
+4. Refresh the page → all previously confirmed and status-available beers reappear (per current `on_tap`/`bottle_can` status) since confirmation state is not persisted.
+5. Confirm every visible row → empty state message appears ("No beers currently available.").
+6. Check phone-width viewport (375px) → confirm button is easily tappable alongside the status `Select`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Tapping "confirm" on a beer row removes it from the visible list without calling `beer.update`
+- [ ] Editing a different beer's status (e.g. to "Out") also removes that item from the list, and the two removal paths (confirm vs. edit) don't interfere with each other
+- [ ] Refreshing or navigating away and back to `/beer/inventory` clears confirmation state (previously confirmed items reappear)
+- [ ] A visible count of remaining (unconfirmed) items is shown in the header
+- [ ] Type check passes (`npm run check`)
+- [ ] Tests pass (`npm test`)
+- [ ] Follows existing patterns (ghost icon button, `Badge` primitive, in-place cache/state updates — no route or server changes)

--- a/.agents/reports/beer-inventory-confirm-present-report.md
+++ b/.agents/reports/beer-inventory-confirm-present-report.md
@@ -1,0 +1,53 @@
+# Implementation Report
+
+**Plan**: `.agents/plans/beer-inventory-confirm-present.plan.md`
+**Branch**: `127/beer-inventory-confirm-present`
+**Status**: COMPLETE
+
+## Summary
+
+Added a "confirmed present" action to each row in Beer Inventory Mode (`client/src/pages/BeerInventory.tsx`). Tapping the checkmark button removes a beer from the visible list via purely local component state (`useState<Set<number>>`) — no `beer.update` mutation is called and no data changes. This is layered independently on top of the existing status-edit removal path (which mutates the `beer.listAvailable` query cache), so the two removal mechanisms don't interfere with each other. A "N remaining" badge was added to the header.
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Add confirmed-IDs state and derive the visible list | `client/src/pages/BeerInventory.tsx` | ✅ |
+| 2 | Render the confirm button per row and switch rendering to `visibleBeers` | `client/src/pages/BeerInventory.tsx` | ✅ |
+| 3 | Show a remaining-count indicator in the header | `client/src/pages/BeerInventory.tsx` | ✅ |
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check | ✅ (pre-existing unrelated errors in `Map.tsx`, `BeerBrowser.tsx`, `Login.tsx`, `server/_core/oauth.ts`, `server/_core/sdk.ts` confirmed present on `main` before this change — none touch `BeerInventory.tsx`) |
+| Build (`npm run build`) | ✅ |
+| Tests (`npm test`) | ✅ (90 passed, 4 files — no server logic changed, no new tests needed for this purely client-side UI-state feature) |
+| E2E (browser, curator session) | ✅ — see below |
+
+## E2E Verification
+
+Ran the dev server locally (port 3001) against the dev DB, authenticated as the curator user via session cookie, and drove `/beer/inventory` with `agent-browser`:
+
+1. Loaded the inventory page with 2 available beers → header showed "2 remaining".
+2. Clicked "Confirm present" on one row → row disappeared immediately, badge updated to "1 remaining", **no new network requests fired** (verified via `agent-browser network requests` before/after — confirms no `beer.update` call).
+3. Changed the remaining beer's status to "Out" via the existing `Select` → that row disappeared too (existing #126 cache-removal path), badge updated to "0 remaining", empty state shown. Confirmed the confirm-path and edit-path operate independently without interfering.
+4. Reloaded the page → the beer that had been **confirmed** (not edited) reappeared with "1 remaining", proving confirmation state is session-only and not persisted, while the beer edited to "Out" correctly stayed gone (real DB state).
+5. Restored the dev DB's test data (`Gordon Strong's Burton Ale` status) back to `on_tap` after testing.
+
+Screenshots taken during verification confirmed the confirm button renders correctly next to the status `Select` and the badge displays as expected.
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `client/src/pages/BeerInventory.tsx` | UPDATE | +30/-14 |
+
+## Deviations from Plan
+
+- Wrapped the `Select` and new confirm `Button` in a `<div className="flex items-center gap-2">` inside `CardContent` so the two controls sit side-by-side correctly — the plan didn't spell out this wrapper explicitly but it's consistent with "add a confirm Button after the Select."
+- `npm run format` reformatted the entire repository (165 files) due to local Prettier/config drift unrelated to this change; those unrelated reformatting changes were reverted, keeping only the intended edit to `BeerInventory.tsx`.
+
+## Tests Written
+
+None — this is a purely client-side UI-state change (local `Set` filtering) with no new server logic, tRPC procedures, or DB access. No automated client test infrastructure exists in this repo (`server/**/*.test.ts` only, per `CLAUDE.md`). Verified via E2E browser testing instead, per plan.

--- a/client/src/pages/BeerInventory.tsx
+++ b/client/src/pages/BeerInventory.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Link, useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Beer } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Beer, Check } from "lucide-react";
 import { toast } from "sonner";
 
 type BeerStatus = "on_tap" | "bottle_can" | "out";
@@ -15,6 +16,8 @@ export default function BeerInventory() {
   const { data: beers, isLoading: beersLoading } = trpc.beer.listAvailable.useQuery();
   const updateMutation = trpc.beer.update.useMutation();
   const utils = trpc.useUtils();
+  const [confirmedIds, setConfirmedIds] = useState<Set<number>>(new Set());
+  const visibleBeers = beers?.filter((b) => !confirmedIds.has(b.beerId));
 
   // Redirect to login if not authenticated or not a curator/admin
   useEffect(() => {
@@ -39,6 +42,10 @@ export default function BeerInventory() {
     }
   };
 
+  const handleConfirm = (beerId: number) => {
+    setConfirmedIds((prev) => new Set(prev).add(beerId));
+  };
+
   if (userLoading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
@@ -61,6 +68,7 @@ export default function BeerInventory() {
           <div className="flex items-center gap-3">
             <Beer className="w-8 h-8 text-amber-600" />
             <h1 className="text-2xl font-bold text-gray-900">Beer Inventory</h1>
+            {!beersLoading && <Badge variant="secondary">{visibleBeers?.length ?? 0} remaining</Badge>}
           </div>
           <Link href="/dashboard">
             <Button variant="outline" size="sm">
@@ -73,26 +81,36 @@ export default function BeerInventory() {
       <main className="max-w-2xl mx-auto px-4 py-8 space-y-3">
         {beersLoading ? (
           <div className="text-center py-8">Loading...</div>
-        ) : beers?.length === 0 ? (
+        ) : visibleBeers?.length === 0 ? (
           <div className="text-center py-8 text-gray-500">No beers currently available.</div>
         ) : (
-          beers?.map((beer) => (
+          visibleBeers?.map((beer) => (
             <Card key={beer.beerId}>
               <CardContent className="flex items-center justify-between gap-4 py-4">
                 <span className="text-lg font-medium">{beer.name}</span>
-                <Select
-                  value={beer.status ?? "out"}
-                  onValueChange={(value: BeerStatus) => handleStatusChange(beer.beerId, value)}
-                >
-                  <SelectTrigger className="h-12 w-40 text-base">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="on_tap">On Tap</SelectItem>
-                    <SelectItem value="bottle_can">Bottle/Can</SelectItem>
-                    <SelectItem value="out">Out</SelectItem>
-                  </SelectContent>
-                </Select>
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={beer.status ?? "out"}
+                    onValueChange={(value: BeerStatus) => handleStatusChange(beer.beerId, value)}
+                  >
+                    <SelectTrigger className="h-12 w-40 text-base">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="on_tap">On Tap</SelectItem>
+                      <SelectItem value="bottle_can">Bottle/Can</SelectItem>
+                      <SelectItem value="out">Out</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => handleConfirm(beer.beerId)}
+                    aria-label="Confirm present"
+                  >
+                    <Check className="w-4 h-4" />
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           ))


### PR DESCRIPTION
## Summary
- Adds a "confirmed present" checkmark button to each row in Beer Inventory Mode (`client/src/pages/BeerInventory.tsx`) that removes the item from the visible list without calling `beer.update` — purely local session state (`useState<Set<number>>`), no data changes.
- The confirm path and the existing status-edit removal path (#126) operate independently and don't interfere: one filters via local state, the other patches the `beer.listAvailable` query cache.
- Adds a "N remaining" count badge in the header so a curator can see progress through the list.

## Test plan
- [x] `npm run check` — passes (pre-existing unrelated type errors on `main` untouched)
- [x] `npm run build` — passes
- [x] `npm test` — 90 tests passed
- [x] E2E verified in browser as curator: confirming a row removes it with zero network requests fired (no `beer.update` call); editing a different row's status to "Out" removes it independently via the existing path; reloading the page brings back the confirmed-but-not-edited item (session-only, not persisted) while the edited-to-Out item stays gone

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)