### PR TITLE
Add Inventory Mode links to Beer/Wine Management pages

### DIFF
--- a/client/src/pages/BeerManagement.tsx
+++ b/client/src/pages/BeerManagement.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Beer, Layers, MapPin, Menu, Tag } from "lucide-react";
+import { Beer, Layers, ListChecks, MapPin, Menu, Tag } from "lucide-react";
 import { toast } from "sonner";
 import BJCPCategoryPage from "./BJCPCategoryPage";
 import StylePage from "./StylePage";
@@ -67,6 +67,12 @@ export default function BeerManagement() {
             </div>
           </Link>
           <div className="flex items-center gap-4">
+            <Link href="/beer/inventory">
+              <Button variant="outline" size="sm">
+                <ListChecks className="w-4 h-4 mr-1" />
+                Inventory Mode
+              </Button>
+            </Link>
             <Link href="/dashboard">
               <Button variant="outline" size="sm">
                 Back to Dashboard

--- a/client/src/pages/WineManagement.tsx
+++ b/client/src/pages/WineManagement.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Wine, GrapeIcon, MapPinned, Building2 } from "lucide-react";
+import { Wine, GrapeIcon, ListChecks, MapPinned, Building2 } from "lucide-react";
 import { toast } from "sonner";
 import ManageWinePage from "./ManageWinePage";
 import WineryPage from "./WineryPage";
@@ -66,6 +66,12 @@ export default function WineManagement() {
             </div>
           </Link>
           <div className="flex items-center gap-4">
+            <Link href="/wine/inventory">
+              <Button variant="outline" size="sm">
+                <ListChecks className="w-4 h-4 mr-1" />
+                Inventory Mode
+              </Button>
+            </Link>
             <Link href="/dashboard">
               <Button variant="outline" size="sm">
                 Back to Dashboard


### PR DESCRIPTION
## Summary
- Adds an "Inventory Mode" button to `BeerManagement.tsx` and `WineManagement.tsx` headers, linking to `/beer/inventory` and `/wine/inventory` respectively.
- These routes existed but were unreachable from the UI (had to type the URL directly) since #126 merged — this closes that gap for both beer and wine.

## Test plan
- [x] `npm run check` — no new errors
- [x] `npm test` — 90/90 passing
- [x] Verified with a live dev server + `agent-browser`: "Inventory Mode" button renders next to "Back to Dashboard" on both Management pages and navigates to the correct route on click (screenshots taken for both).

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)