### PR TITLE
Show total bottle count on wine browse page

### DIFF
--- a/.agents/plans/completed/wine-browse-bottle-count-summary.plan.md
+++ b/.agents/plans/completed/wine-browse-bottle-count-summary.plan.md
@@ -1,0 +1,130 @@
+# Plan: Wine Browse Page Bottle Count Summary
+
+## Summary
+
+The wine browse page (`WinePage.tsx`) currently shows only a wine count ("Showing N wines"). We'll add a total bottle count to the same summary line, computed client-side by summing each wine's `refrigerated` + `cellared` fields, which are already present on every object returned by `trpc.wine.listAvailable`. No schema, router, or DB changes are needed — this is a pure client-side rendering change.
+
+## User Story
+
+As a visitor browsing the wine menu
+I want to see the total number of bottles available, not just the number of distinct wines
+So that I get a quick sense of overall stock, not just variety
+
+## Metadata
+
+| Field            | Value                 |
+| ---------------- | --------------------- |
+| Type             | ENHANCEMENT           |
+| Complexity       | LOW                   |
+| Systems Affected | client (WinePage.tsx) |
+| GitHub Issue     | 142                   |
+
+---
+
+## Patterns to Follow
+
+### Naming / existing summary text
+
+```tsx
+// SOURCE: client/src/pages/WinePage.tsx:213-216
+<p className="text-sm text-gray-600 mb-6">
+  Showing {availableWines.length} wine
+  {availableWines.length !== 1 ? "s" : ""}
+</p>
+```
+
+### Per-wine bottle fields already available
+
+```tsx
+// SOURCE: client/src/pages/WinePage.tsx:250-255
+<div className="flex gap-4 text-sm text-gray-700 pt-2">
+  {wine.refrigerated > 0 && <span className="font-medium">🧊 Refrigerated: {wine.refrigerated}</span>}
+  {wine.cellared > 0 && <span className="font-medium">🍷 Cellared: {wine.cellared}</span>}
+</div>
+```
+
+### Data source
+
+```tsx
+// SOURCE: client/src/pages/WinePage.tsx:57-61
+const { data: availableWines = [], isLoading } = trpc.wine.listAvailable.useQuery({
+  locationIds: selectedLocations.map((id) => parseInt(id, 10)),
+  wineryIds: selectedWineries.map((id) => parseInt(id, 10)),
+});
+```
+
+Each item in `availableWines` includes `refrigerated: number` and `cellared: number` (from `server/db_wine.ts:getAvailableWinesFiltered`, `drizzle/schema.ts:211-212`).
+
+### Tests
+
+No client-side test files exist in this repo (`client/src` has none) — this change will not add a new test, consistent with the rest of the client codebase's coverage pattern. Server-side logic is unchanged, so no server test additions are needed either.
+
+---
+
+## Files to Change
+
+| File                            | Action | Purpose                                                                                              |
+| ------------------------------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| `client/src/pages/WinePage.tsx` | UPDATE | Compute total bottle count and update the summary paragraph to show both wine count and bottle count |
+
+---
+
+## Tasks
+
+Execute in order. Each task is atomic and verifiable.
+
+### Task 1: Compute total bottle count
+
+- **File**: `client/src/pages/WinePage.tsx`
+- **Action**: UPDATE
+- **Implement**: Add a derived `totalBottles` value just after the `availableWines` query (near line 61), summing `refrigerated + cellared` across `availableWines`:
+  ```ts
+  const totalBottles = availableWines.reduce((sum, wine) => sum + wine.refrigerated + wine.cellared, 0);
+  ```
+- **Mirror**: `client/src/pages/WinePage.tsx:57-61` (existing query destructuring style, same component scope)
+- **Validate**: `npm run check`
+
+### Task 2: Update the summary paragraph to show bottle count
+
+- **File**: `client/src/pages/WinePage.tsx`
+- **Action**: UPDATE
+- **Implement**: Replace the summary text at lines 213-216 to include both counts, keeping the existing singular/plural handling for "wine(s)" and adding equivalent handling for "bottle(s)":
+  ```tsx
+  <p className="text-sm text-gray-600 mb-6">
+    Showing {availableWines.length} wine
+    {availableWines.length !== 1 ? "s" : ""} ({totalBottles} bottle
+    {totalBottles !== 1 ? "s" : ""})
+  </p>
+  ```
+- **Mirror**: `client/src/pages/WinePage.tsx:213-216` (existing pluralization pattern)
+- **Validate**: `npm run check`
+
+---
+
+## Validation
+
+```bash
+# Format (auto-fixes in place)
+npm run format
+
+# Type check
+npm run check
+
+# Production build (catches bundling issues npm run check won't)
+npm run build
+
+# Tests (no wine-page-specific tests exist; run full suite to confirm no regressions)
+npm test
+```
+
+Manual check: run `npm run dev`, visit `/wine`, confirm the summary line shows both the wine count and total bottle count, and that the number matches the sum of each card's Refrigerated/Cellared badges.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Wine browse page summary shows both number of wines and total number of bottles
+- [ ] Singular/plural wording is correct for both counts (1 wine / N wines, 1 bottle / N bottles)
+- [ ] Type check passes
+- [ ] No regressions in existing tests
+- [ ] Follows existing patterns (no new schema/router/DB changes)

--- a/.agents/reports/wine-browse-bottle-count-summary-report.md
+++ b/.agents/reports/wine-browse-bottle-count-summary-report.md
@@ -1,0 +1,47 @@
+# Implementation Report
+
+**Plan**: `.agents/plans/wine-browse-bottle-count-summary.plan.md`
+**Branch**: `142/wine-browse-bottle-count-summary`
+**Status**: COMPLETE
+
+## Summary
+
+Added a total bottle count to the wine browse page summary line, alongside the existing wine count. The total is computed client-side by summing each wine's `refrigerated` + `cellared` fields, which were already present on every object returned by `trpc.wine.listAvailable`. No schema, router, or DB changes were needed.
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Compute total bottle count via `reduce` over `availableWines` | `client/src/pages/WinePage.tsx` | ✅ |
+| 2 | Update summary paragraph to show both wine count and bottle count | `client/src/pages/WinePage.tsx` | ✅ |
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Format | ✅ (no changes needed — already matched Prettier style) |
+| Type check | ✅ |
+| Build | ✅ |
+| Tests | ✅ (90 passed, 4 test files) |
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `client/src/pages/WinePage.tsx` | UPDATE | +4/-1 |
+
+## Deviations from Plan
+
+None. Implementation matched the plan exactly.
+
+## Tests Written
+
+None — no client-side test files exist in this repo, consistent with existing coverage patterns. Server-side logic was unchanged, so no server test additions were needed.
+
+## End-to-End Verification
+
+Started dev server (`npm run dev`, port 3001) and test DB, then verified via `agent-browser`:
+- Navigated to `http://localhost:3001/wine`
+- Rendered summary text: **"Showing 2 wines (6 bottles)"**
+- Confirmed against raw tRPC data (`wine.listAvailable`): 2 wines with `refrigerated`/`cellared` of (2,2) and (2,0) → total bottles = 6, matching
+- Screenshot confirmed correct visual placement of the new bottle count next to the wine count

--- a/client/src/pages/WinePage.tsx
+++ b/client/src/pages/WinePage.tsx
@@ -60,6 +60,8 @@ export default function WinePage() {
     wineryIds: selectedWineries.map((id) => parseInt(id, 10)),
   });
 
+  const totalBottles = availableWines.reduce((sum, wine) => sum + wine.refrigerated + wine.cellared, 0);
+
   // Fetch only locations that have available wines (for filter options)
   const { data: locations = [] } = trpc.location.listAvailable.useQuery();
 
@@ -212,7 +214,8 @@ export default function WinePage() {
           <>
             <p className="text-sm text-gray-600 mb-6">
               Showing {availableWines.length} wine
-              {availableWines.length !== 1 ? "s" : ""}
+              {availableWines.length !== 1 ? "s" : ""} ({totalBottles} bottle
+              {totalBottles !== 1 ? "s" : ""})
             </p>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {availableWines.map((wine) => (


### PR DESCRIPTION
## Summary
- Added a `totalBottles` calculation on the wine browse page, summing `refrigerated` + `cellared` across all currently displayed wines
- Updated the summary line to show both the wine count and the total bottle count (e.g. "Showing 2 wines (6 bottles)")

## Test plan
- [x] `npm run check` passes
- [x] `npm run build` passes
- [x] `npm test` passes (90/90)
- [x] Verified in browser: `/wine` page shows "Showing 2 wines (6 bottles)", matching the sum of `refrigerated`/`cellared` from the seeded test data

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)