### PR TITLE
fix: make dialogs scrollable, keyboard-safe, and full-width on mobile

### DIFF
--- a/.agents/plans/completed/improve-mobile-beer-management-dialogs.plan.md
+++ b/.agents/plans/completed/improve-mobile-beer-management-dialogs.plan.md
@@ -1,0 +1,141 @@
+# Plan: Improve Mobile View for Beer Management Dialogs
+
+## Summary
+
+On mobile, the "Add Brewery" and "Add Beer" dialogs are unusable: the base `DialogContent` component has no max-height or scroll behavior, so a dialog taller than the viewport (like the 8-field Add Beer form) gets clipped with no way to scroll to the rest of it. Separately, the on-screen keyboard hides the Add Brewery dialog because the viewport meta tag doesn't tell modern Android Chrome to resize the layout viewport when the keyboard opens, so the fixed, vertically-centered dialog doesn't reflow. The fix is a small, global change to the base Dialog component (matching a pattern already proven in `ManageWinePage.tsx`) plus a viewport meta tag addition — no page-specific hacks needed, and every dialog in the app benefits.
+
+## User Story
+
+As a mobile user
+I want to fully see and interact with the Add Beer and Add Brewery dialogs
+So that I can add catalog items from my phone without content being cut off or hidden by the keyboard
+
+## Metadata
+
+| Field            | Value                                                        |
+| ---------------- | ------------------------------------------------------------ |
+| Type             | BUG_FIX                                                      |
+| Complexity       | LOW                                                          |
+| Systems Affected | Frontend (shared UI component, one page cleanup, HTML shell) |
+| GitHub Issue     | 145                                                          |
+
+---
+
+## Patterns to Follow
+
+### Existing proven fix for dialog height/scroll (copy this into the base component)
+
+```tsx
+// SOURCE: client/src/pages/ManageWinePage.tsx:206
+<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+```
+
+This is currently the _only_ dialog in the app with mobile-safe height handling. Every other dialog (`BreweryPage.tsx:84`, `BeerPage.tsx:159`, `WineryPage.tsx:110`, `VarietalPage.tsx:84`, `StylePage.tsx:107`, `MenuCategoryPage.tsx:129`, `BJCPCategoryPage.tsx:83`, `LocationPage.tsx:134`) lacks it. Rather than patching each page, fix it once in the base component.
+
+### Base Dialog component (where the fix goes)
+
+```tsx
+// SOURCE: client/src/components/ui/dialog.tsx:112-120
+<DialogPrimitive.Content
+  data-slot="dialog-content"
+  className={cn(
+    "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+    className
+  )}
+  ...
+```
+
+`cn()` uses `tailwind-merge` (`client/src/lib/utils.ts:1-5`), so adding `max-h-[90vh] overflow-y-auto` here is additive — it won't conflict with per-page `className` overrides like `BeerPage.tsx`'s `max-w-md`, since those only touch width, not height/overflow.
+
+### Class merging behavior (why this is safe)
+
+```tsx
+// SOURCE: client/src/lib/utils.ts:1-5
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+---
+
+## Files to Change
+
+| File                                  | Action | Purpose                                                                                  |
+| ------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
+| `client/index.html`                   | UPDATE | Add `interactive-widget=resizes-content` to the viewport meta tag for keyboard avoidance |
+| `client/src/components/ui/dialog.tsx` | UPDATE | Add `max-h-[90vh] overflow-y-auto` to the base `DialogContent` classes                   |
+| `client/src/pages/ManageWinePage.tsx` | UPDATE | Remove now-redundant `max-h-[90vh] overflow-y-auto` from its `DialogContent` override    |
+
+---
+
+## Tasks
+
+### Task 1: Add keyboard-avoidance viewport meta option
+
+- **File**: `client/index.html`
+- **Action**: UPDATE
+- **Implement**: Change the viewport meta tag at line 5 from
+  `content="width=device-width, initial-scale=1.0, maximum-scale=1"`
+  to
+  `content="width=device-width, initial-scale=1.0, maximum-scale=1, interactive-widget=resizes-content"`.
+  This tells modern Chrome/Android to resize the layout viewport (not just the visual viewport) when the on-screen keyboard opens, so a `fixed`, vertically-centered dialog reflows instead of being pushed/hidden behind the keyboard. It's a progressive enhancement — unsupported browsers (e.g. Safari) simply ignore the unknown token with no downside.
+- **Mirror**: N/A — no existing example in this codebase; this is a one-line meta tag addition.
+- **Validate**: `npm run check`
+
+### Task 2: Make the base Dialog scrollable on all viewports
+
+- **File**: `client/src/components/ui/dialog.tsx`
+- **Action**: UPDATE
+- **Implement**: In `DialogContent` (around line 115), add `max-h-[90vh] overflow-y-auto` to the class string passed to `cn(...)`, so it reads (order within the string doesn't matter, but keep it readable):
+  `"... fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg"`.
+  This is a global fix: it resolves the Add Beer "cut off" bug (8-field form now scrolls within the dialog instead of overflowing off-screen) and also benefits every other dialog in the app (Add Brewery, Style, Menu Category, Location, etc.) without touching each page individually.
+- **Mirror**: `client/src/pages/ManageWinePage.tsx:206` — same class values, proven pattern.
+- **Validate**: `npm run check`
+
+### Task 3: Remove now-redundant override in ManageWinePage
+
+- **File**: `client/src/pages/ManageWinePage.tsx`
+- **Action**: UPDATE
+- **Implement**: At line 206, since the base `DialogContent` now provides `max-h-[90vh] overflow-y-auto` by default, simplify `className="max-w-2xl max-h-[90vh] overflow-y-auto"` to `className="max-w-2xl"` to avoid duplicating a class that's now inherited.
+- **Mirror**: N/A — straightforward cleanup following Task 2's change.
+- **Validate**: `npm run check`
+
+---
+
+## Validation
+
+```bash
+# Format (auto-fixes in place)
+npm run format
+
+# Type check
+npm run check
+
+# Production build (catches bundling issues npm run check won't)
+npm run build
+
+# Tests
+npm test
+```
+
+Manual verification (no automated test coverage exists for base UI components in this repo — tests are server-only per `server/**/*.test.ts`):
+
+1. In Chrome DevTools, emulate a Pixel 9 Pro XL (or similar tall/narrow device) viewport.
+2. Open Beer management → "Add Beer" → confirm the dialog no longer clips content; the form scrolls internally and the submit button is reachable.
+3. Open Brewery management → "Add Brewery" → focus the name/location inputs and confirm the on-screen keyboard (or its DevTools equivalent — toggle device toolbar's viewport resize) doesn't hide the dialog; the dialog reflows/stays visible.
+4. Spot-check one or two other dialogs (e.g. Style, Location) to confirm the global change didn't break their layout on both desktop and mobile widths.
+
+---
+
+## Acceptance Criteria
+
+- [ ] All tasks completed
+- [ ] Type check passes
+- [ ] Production build passes
+- [ ] Add Beer dialog is fully scrollable and usable on a narrow/tall mobile viewport
+- [ ] Add Brewery dialog remains visible/usable when the on-screen keyboard is open on Android Chrome
+- [ ] No regression in other dialogs (Style, Location, Menu Category, Wine, etc.) at desktop and mobile widths
+- [ ] Follows existing patterns (base component fix mirrors `ManageWinePage.tsx`'s already-proven approach)

--- a/.agents/reports/improve-mobile-beer-management-dialogs-report.md
+++ b/.agents/reports/improve-mobile-beer-management-dialogs-report.md
@@ -8,34 +8,36 @@
 
 Fixed two mobile display bugs from issue #145: the Add Beer dialog was clipped on tall/narrow viewports (no max-height or scroll on the base Dialog component), and the Add Brewery dialog could be hidden by the on-screen keyboard on Android Chrome (viewport meta tag didn't opt into layout-viewport resizing). Both fixes were applied globally in the base `DialogContent` component and `index.html` rather than per-page, so every dialog in the app benefits, and a redundant duplicate of the fix was removed from `ManageWinePage.tsx`.
 
+**Follow-up after manual testing**: the user tested with Chrome DevTools device emulation (Pixel 7) and found the dialog still appeared vertically centered with its top roughly mid-screen — for a short dialog like Add Brewery (2 fields), that leaves little margin before the keyboard would cover the inputs, and relying solely on `interactive-widget=resizes-content` isn't enough since iOS Safari doesn't support it at all. Changed `DialogContent` to anchor near the top of the viewport (`top-[5%]`, no vertical translate) on mobile widths, reverting to true vertical centering (`sm:top-[50%] sm:translate-y-[-50%]`) at the `sm` breakpoint and up, where keyboard overlap isn't a concern.
+
 ## Tasks Completed
 
-| #   | Task                                                          | File                                   | Status |
-| --- | -------------------------------------------------------------- | --------------------------------------- | ------ |
-| 1   | Add `interactive-widget=resizes-content` to viewport meta tag | `client/index.html`                    | ✅     |
-| 2   | Add `max-h-[90vh] overflow-y-auto` to base `DialogContent`    | `client/src/components/ui/dialog.tsx`  | ✅     |
-| 3   | Remove now-redundant override in ManageWinePage               | `client/src/pages/ManageWinePage.tsx`  | ✅     |
+| #   | Task                                                          | File                                  | Status |
+| --- | ------------------------------------------------------------- | ------------------------------------- | ------ |
+| 1   | Add `interactive-widget=resizes-content` to viewport meta tag | `client/index.html`                   | ✅     |
+| 2   | Add `max-h-[90vh] overflow-y-auto` to base `DialogContent`    | `client/src/components/ui/dialog.tsx` | ✅     |
+| 3   | Remove now-redundant override in ManageWinePage               | `client/src/pages/ManageWinePage.tsx` | ✅     |
 
 ## Validation Results
 
-| Check      | Result                         |
-| ---------- | ------------------------------- |
-| Format     | ✅                              |
-| Type check | ✅                              |
-| Build      | ✅                              |
-| Tests      | ✅ (90 passed, 4 test files)    |
+| Check      | Result                       |
+| ---------- | ---------------------------- |
+| Format     | ✅                           |
+| Type check | ✅                           |
+| Build      | ✅                           |
+| Tests      | ✅ (90 passed, 4 test files) |
 
 ## Files Changed
 
-| File                                    | Action | Lines |
-| ---------------------------------------- | ------ | ----- |
-| `client/index.html`                     | UPDATE | +4/-1 |
-| `client/src/components/ui/dialog.tsx`   | UPDATE | +1/-1 |
-| `client/src/pages/ManageWinePage.tsx`   | UPDATE | +1/-1 |
+| File                                  | Action | Lines |
+| ------------------------------------- | ------ | ----- |
+| `client/index.html`                   | UPDATE | +4/-1 |
+| `client/src/components/ui/dialog.tsx` | UPDATE | +1/-1 |
+| `client/src/pages/ManageWinePage.tsx` | UPDATE | +1/-1 |
 
 ## Deviations from Plan
 
-None. Implementation matched the plan exactly.
+Added one change beyond the original plan, based on user feedback from manual testing: anchoring `DialogContent` near the top of the viewport on mobile (`top-[5%]`, no vertical translate) instead of relying only on vertical centering, since centering alone put short dialogs' inputs too close to where an on-screen keyboard would appear, and `interactive-widget=resizes-content` isn't supported on all browsers (notably iOS Safari).
 
 ## Tests Written
 

--- a/.agents/reports/improve-mobile-beer-management-dialogs-report.md
+++ b/.agents/reports/improve-mobile-beer-management-dialogs-report.md
@@ -12,6 +12,10 @@ Fixed two mobile display bugs from issue #145: the Add Beer dialog was clipped o
 
 **Follow-up after manual testing (round 2)**: the user reported the dialog was now correctly positioned near the top but still horizontally offset with side margins, and asked for it to take the full width on phone-sized viewports. Changed `DialogContent` to drop the `max-w-[calc(100%-2rem)]` cap and horizontal centering transform on mobile (`left-0`, no `translate-x`, `w-full` with no max-width), so it spans edge-to-edge, while keeping the centered card look (`sm:left-[50%] sm:-translate-x-1/2 sm:max-w-lg`) at the `sm` breakpoint and up.
 
+**Follow-up after manual testing (round 3)**: the user reported the dialog was still wider than the screen. A console check (`getBoundingClientRect()` vs `window.innerWidth`/`document.documentElement.clientWidth`) showed `dialogWidth: 448` (exactly `max-w-md`, 28rem) against a visible `clientWidth: 412`, while `window.innerWidth`/`scrollWidth` both read `686`. Two compounding bugs:
+1. `BeerPage.tsx`, `StylePage.tsx`, and `ManageWinePage.tsx` override `DialogContent` with an unprefixed `max-w-md`/`max-w-2xl`, which — being unprefixed — applies at every breakpoint including mobile, capping the dialog at a fixed pixel width regardless of the phone's actual width (per user: "different phones will have different widths... we want to use 100% of the width, not a fixed pixel width"). Fixed by making these `sm:max-w-md` / `sm:max-w-2xl` so they only take effect at the `sm` breakpoint and up, leaving the base component's unconstrained mobile width in effect on phones.
+2. `BeerManagement.tsx`'s header row (logo, 3 buttons, and a "Welcome, {name}" string) had no `flex-wrap` and needed ~606px to lay out — wider than a 412px phone screen. This forced the browser's CSS layout viewport itself to inflate (explaining `innerWidth: 686`), corrupting every percentage/vw-based width calculation on the page, not just the dialog's. Fixed by adding `flex-wrap` to the header's outer and inner flex containers, hiding the "Welcome, {name}" text below `sm`, and tightening the mobile gap — verified with an isolated Playwright check that the header now fits exactly within a 412px viewport (was 606px, now 412px, no overflow).
+
 ## Tasks Completed
 
 | #   | Task                                                          | File                                  | Status |
@@ -31,17 +35,22 @@ Fixed two mobile display bugs from issue #145: the Add Beer dialog was clipped o
 
 ## Files Changed
 
-| File                                  | Action | Lines |
-| ------------------------------------- | ------ | ----- |
-| `client/index.html`                   | UPDATE | +4/-1 |
-| `client/src/components/ui/dialog.tsx` | UPDATE | +1/-1 |
-| `client/src/pages/ManageWinePage.tsx` | UPDATE | +1/-1 |
+| File                                    | Action | Lines |
+| --------------------------------------- | ------ | ----- |
+| `client/index.html`                     | UPDATE | +4/-1 |
+| `client/src/components/ui/dialog.tsx`   | UPDATE | +1/-1 |
+| `client/src/pages/ManageWinePage.tsx`   | UPDATE | +1/-1 |
+| `client/src/pages/BeerPage.tsx`         | UPDATE | +1/-1 |
+| `client/src/pages/StylePage.tsx`        | UPDATE | +1/-1 |
+| `client/src/pages/BeerManagement.tsx`   | UPDATE | +4/-4 |
 
 ## Deviations from Plan
 
 Added two changes beyond the original plan, based on user feedback from manual testing:
+
 1. Anchoring `DialogContent` near the top of the viewport on mobile (`top-[5%]`, no vertical translate) instead of relying only on vertical centering, since centering alone put short dialogs' inputs too close to where an on-screen keyboard would appear, and `interactive-widget=resizes-content` isn't supported on all browsers (notably iOS Safari).
 2. Making `DialogContent` full-width edge-to-edge on mobile (dropping the side margin and horizontal centering transform below the `sm` breakpoint) per explicit user request, while preserving the centered card layout on larger screens.
+3. Making per-page `DialogContent` width overrides (`BeerPage.tsx`, `StylePage.tsx`, `ManageWinePage.tsx`) responsive (`sm:max-w-*` instead of unprefixed `max-w-*`), and fixing `BeerManagement.tsx`'s header to wrap on mobile instead of forcing horizontal page overflow — both found via user-provided console diagnostics during manual testing.
 
 ## Tests Written
 

--- a/.agents/reports/improve-mobile-beer-management-dialogs-report.md
+++ b/.agents/reports/improve-mobile-beer-management-dialogs-report.md
@@ -13,8 +13,11 @@ Fixed two mobile display bugs from issue #145: the Add Beer dialog was clipped o
 **Follow-up after manual testing (round 2)**: the user reported the dialog was now correctly positioned near the top but still horizontally offset with side margins, and asked for it to take the full width on phone-sized viewports. Changed `DialogContent` to drop the `max-w-[calc(100%-2rem)]` cap and horizontal centering transform on mobile (`left-0`, no `translate-x`, `w-full` with no max-width), so it spans edge-to-edge, while keeping the centered card look (`sm:left-[50%] sm:-translate-x-1/2 sm:max-w-lg`) at the `sm` breakpoint and up.
 
 **Follow-up after manual testing (round 3)**: the user reported the dialog was still wider than the screen. A console check (`getBoundingClientRect()` vs `window.innerWidth`/`document.documentElement.clientWidth`) showed `dialogWidth: 448` (exactly `max-w-md`, 28rem) against a visible `clientWidth: 412`, while `window.innerWidth`/`scrollWidth` both read `686`. Two compounding bugs:
+
 1. `BeerPage.tsx`, `StylePage.tsx`, and `ManageWinePage.tsx` override `DialogContent` with an unprefixed `max-w-md`/`max-w-2xl`, which — being unprefixed — applies at every breakpoint including mobile, capping the dialog at a fixed pixel width regardless of the phone's actual width (per user: "different phones will have different widths... we want to use 100% of the width, not a fixed pixel width"). Fixed by making these `sm:max-w-md` / `sm:max-w-2xl` so they only take effect at the `sm` breakpoint and up, leaving the base component's unconstrained mobile width in effect on phones.
 2. `BeerManagement.tsx`'s header row (logo, 3 buttons, and a "Welcome, {name}" string) had no `flex-wrap` and needed ~606px to lay out — wider than a 412px phone screen. This forced the browser's CSS layout viewport itself to inflate (explaining `innerWidth: 686`), corrupting every percentage/vw-based width calculation on the page, not just the dialog's. Fixed by adding `flex-wrap` to the header's outer and inner flex containers, hiding the "Welcome, {name}" text below `sm`, and tightening the mobile gap — verified with an isolated Playwright check that the header now fits exactly within a 412px viewport (was 606px, now 412px, no overflow).
+
+**Follow-up (wine management)**: the user asked for the same fix on the wine management dialogs. `WineryPage.tsx`, `VarietalPage.tsx`, and `LocationPage.tsx` already use the base `DialogContent` with no width override, so they picked up the mobile full-width fix automatically. `WineManagement.tsx`'s header had the exact same unwrapped flex-row pattern (logo, 2 buttons, "Welcome, {name}") as `BeerManagement.tsx`'s pre-fix header, so applied the identical `flex-wrap` / `hidden sm:inline` / tightened-gap treatment there too.
 
 ## Tasks Completed
 
@@ -35,14 +38,15 @@ Fixed two mobile display bugs from issue #145: the Add Beer dialog was clipped o
 
 ## Files Changed
 
-| File                                    | Action | Lines |
-| --------------------------------------- | ------ | ----- |
-| `client/index.html`                     | UPDATE | +4/-1 |
-| `client/src/components/ui/dialog.tsx`   | UPDATE | +1/-1 |
-| `client/src/pages/ManageWinePage.tsx`   | UPDATE | +1/-1 |
-| `client/src/pages/BeerPage.tsx`         | UPDATE | +1/-1 |
-| `client/src/pages/StylePage.tsx`        | UPDATE | +1/-1 |
-| `client/src/pages/BeerManagement.tsx`   | UPDATE | +4/-4 |
+| File                                  | Action | Lines |
+| ------------------------------------- | ------ | ----- |
+| `client/index.html`                   | UPDATE | +4/-1 |
+| `client/src/components/ui/dialog.tsx` | UPDATE | +1/-1 |
+| `client/src/pages/ManageWinePage.tsx` | UPDATE | +1/-1 |
+| `client/src/pages/BeerPage.tsx`       | UPDATE | +1/-1 |
+| `client/src/pages/StylePage.tsx`      | UPDATE | +1/-1 |
+| `client/src/pages/BeerManagement.tsx` | UPDATE | +4/-4 |
+| `client/src/pages/WineManagement.tsx` | UPDATE | +4/-4 |
 
 ## Deviations from Plan
 

--- a/.agents/reports/improve-mobile-beer-management-dialogs-report.md
+++ b/.agents/reports/improve-mobile-beer-management-dialogs-report.md
@@ -8,7 +8,9 @@
 
 Fixed two mobile display bugs from issue #145: the Add Beer dialog was clipped on tall/narrow viewports (no max-height or scroll on the base Dialog component), and the Add Brewery dialog could be hidden by the on-screen keyboard on Android Chrome (viewport meta tag didn't opt into layout-viewport resizing). Both fixes were applied globally in the base `DialogContent` component and `index.html` rather than per-page, so every dialog in the app benefits, and a redundant duplicate of the fix was removed from `ManageWinePage.tsx`.
 
-**Follow-up after manual testing**: the user tested with Chrome DevTools device emulation (Pixel 7) and found the dialog still appeared vertically centered with its top roughly mid-screen — for a short dialog like Add Brewery (2 fields), that leaves little margin before the keyboard would cover the inputs, and relying solely on `interactive-widget=resizes-content` isn't enough since iOS Safari doesn't support it at all. Changed `DialogContent` to anchor near the top of the viewport (`top-[5%]`, no vertical translate) on mobile widths, reverting to true vertical centering (`sm:top-[50%] sm:translate-y-[-50%]`) at the `sm` breakpoint and up, where keyboard overlap isn't a concern.
+**Follow-up after manual testing (round 1)**: the user tested with Chrome DevTools device emulation (Pixel 7) and found the dialog still appeared vertically centered with its top roughly mid-screen — for a short dialog like Add Brewery (2 fields), that leaves little margin before the keyboard would cover the inputs, and relying solely on `interactive-widget=resizes-content` isn't enough since iOS Safari doesn't support it at all. Changed `DialogContent` to anchor near the top of the viewport (`top-[5%]`, no vertical translate) on mobile widths, reverting to true vertical centering (`sm:top-[50%] sm:translate-y-[-50%]`) at the `sm` breakpoint and up, where keyboard overlap isn't a concern.
+
+**Follow-up after manual testing (round 2)**: the user reported the dialog was now correctly positioned near the top but still horizontally offset with side margins, and asked for it to take the full width on phone-sized viewports. Changed `DialogContent` to drop the `max-w-[calc(100%-2rem)]` cap and horizontal centering transform on mobile (`left-0`, no `translate-x`, `w-full` with no max-width), so it spans edge-to-edge, while keeping the centered card look (`sm:left-[50%] sm:-translate-x-1/2 sm:max-w-lg`) at the `sm` breakpoint and up.
 
 ## Tasks Completed
 
@@ -37,7 +39,9 @@ Fixed two mobile display bugs from issue #145: the Add Beer dialog was clipped o
 
 ## Deviations from Plan
 
-Added one change beyond the original plan, based on user feedback from manual testing: anchoring `DialogContent` near the top of the viewport on mobile (`top-[5%]`, no vertical translate) instead of relying only on vertical centering, since centering alone put short dialogs' inputs too close to where an on-screen keyboard would appear, and `interactive-widget=resizes-content` isn't supported on all browsers (notably iOS Safari).
+Added two changes beyond the original plan, based on user feedback from manual testing:
+1. Anchoring `DialogContent` near the top of the viewport on mobile (`top-[5%]`, no vertical translate) instead of relying only on vertical centering, since centering alone put short dialogs' inputs too close to where an on-screen keyboard would appear, and `interactive-widget=resizes-content` isn't supported on all browsers (notably iOS Safari).
+2. Making `DialogContent` full-width edge-to-edge on mobile (dropping the side margin and horizontal centering transform below the `sm` breakpoint) per explicit user request, while preserving the centered card layout on larger screens.
 
 ## Tests Written
 

--- a/.agents/reports/improve-mobile-beer-management-dialogs-report.md
+++ b/.agents/reports/improve-mobile-beer-management-dialogs-report.md
@@ -1,0 +1,52 @@
+# Implementation Report
+
+**Plan**: `.agents/plans/improve-mobile-beer-management-dialogs.plan.md`
+**Branch**: `145/improve-mobile-beer-management-dialogs`
+**Status**: COMPLETE
+
+## Summary
+
+Fixed two mobile display bugs from issue #145: the Add Beer dialog was clipped on tall/narrow viewports (no max-height or scroll on the base Dialog component), and the Add Brewery dialog could be hidden by the on-screen keyboard on Android Chrome (viewport meta tag didn't opt into layout-viewport resizing). Both fixes were applied globally in the base `DialogContent` component and `index.html` rather than per-page, so every dialog in the app benefits, and a redundant duplicate of the fix was removed from `ManageWinePage.tsx`.
+
+## Tasks Completed
+
+| #   | Task                                                          | File                                   | Status |
+| --- | -------------------------------------------------------------- | --------------------------------------- | ------ |
+| 1   | Add `interactive-widget=resizes-content` to viewport meta tag | `client/index.html`                    | ✅     |
+| 2   | Add `max-h-[90vh] overflow-y-auto` to base `DialogContent`    | `client/src/components/ui/dialog.tsx`  | ✅     |
+| 3   | Remove now-redundant override in ManageWinePage               | `client/src/pages/ManageWinePage.tsx`  | ✅     |
+
+## Validation Results
+
+| Check      | Result                         |
+| ---------- | ------------------------------- |
+| Format     | ✅                              |
+| Type check | ✅                              |
+| Build      | ✅                              |
+| Tests      | ✅ (90 passed, 4 test files)    |
+
+## Files Changed
+
+| File                                    | Action | Lines |
+| ---------------------------------------- | ------ | ----- |
+| `client/index.html`                     | UPDATE | +4/-1 |
+| `client/src/components/ui/dialog.tsx`   | UPDATE | +1/-1 |
+| `client/src/pages/ManageWinePage.tsx`   | UPDATE | +1/-1 |
+
+## Deviations from Plan
+
+None. Implementation matched the plan exactly.
+
+## Tests Written
+
+No new automated tests were written — this is a CSS-only fix to the base Dialog component and an HTML meta tag change, consistent with the plan's note that no automated test coverage exists for base UI components in this repo (tests are server-only, per `server/**/*.test.ts`).
+
+## End-to-End Verification
+
+The app requires real Google OAuth login with no dev-mode bypass, and the Add Beer/Add Brewery dialogs are gated behind curator/admin auth, so driving the actual login flow in an automated browser wasn't feasible in this session. Instead, verified the compiled production CSS directly with Playwright at a Pixel-class viewport (412×915):
+
+- **Before fix** (base classes without `max-h-[90vh] overflow-y-auto`): a dialog with tall content rendered at 2050px height, positioned at `y: -567.5` — pushed off-screen top and bottom with no way to scroll to the rest of it. This reproduces the reported "cut off" bug.
+- **After fix** (actual shipped classes from `dist/public/assets/*.css`): the same tall content now renders at 823.5px height (bounded by `max-height: 823.5px`, i.e. 90% of the 915px viewport), with `overflow-y: auto` and `scrollHeight (2048) > clientHeight (822)` — confirming the content is fully reachable via internal scroll instead of being clipped.
+- Confirmed the built `dist/public/index.html` contains the updated viewport meta tag with `interactive-widget=resizes-content`.
+
+This validates the fix at the compiled-artifact level for both dialogs (both consume the same base `DialogContent`). Manual verification in a real mobile browser against a logged-in session is still recommended before merge, per the plan's manual verification steps.

--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1, interactive-widget=resizes-content"
+    />
     <link rel="icon" type="image/png" href="%VITE_APP_LOGO%" />
     <link rel="apple-touch-icon" href="%VITE_APP_LOGO%" />
     <title>%VITE_APP_TITLE%</title>

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -112,7 +112,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[5%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] overflow-y-auto translate-x-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:top-[50%] sm:max-w-lg sm:translate-y-[-50%]",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[5%] left-0 z-50 grid w-full max-h-[90vh] overflow-y-auto gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:top-[50%] sm:left-[50%] sm:max-w-lg sm:-translate-x-1/2 sm:translate-y-[-50%]",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -112,7 +112,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -112,7 +112,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[5%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] overflow-y-auto translate-x-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:top-[50%] sm:max-w-lg sm:translate-y-[-50%]",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}

--- a/client/src/pages/BeerManagement.tsx
+++ b/client/src/pages/BeerManagement.tsx
@@ -56,14 +56,14 @@ export default function BeerManagement() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white border-b border-gray-200 shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex flex-wrap justify-between items-center gap-y-2">
           <Link href="/">
             <div className="flex items-center gap-3">
               <Beer className="w-8 h-8 text-amber-600" />
               <h1 className="text-2xl font-bold text-gray-900">Beer Management</h1>
             </div>
           </Link>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-4">
             <Link href="/beer/inventory">
               <Button variant="outline" size="sm">
                 <ListChecks className="w-4 h-4 mr-1" />
@@ -77,7 +77,7 @@ export default function BeerManagement() {
             </Link>
             {user && (
               <>
-                <span className="text-sm text-gray-600">Welcome, {user.name}</span>
+                <span className="hidden sm:inline text-sm text-gray-600">Welcome, {user.name}</span>
                 <Button variant="outline" size="sm" onClick={handleLogout}>
                   Logout
                 </Button>

--- a/client/src/pages/BeerPage.tsx
+++ b/client/src/pages/BeerPage.tsx
@@ -156,7 +156,7 @@ export default function BeerPage() {
               Add Beer
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-w-md">
+          <DialogContent className="sm:max-w-md">
             <DialogHeader>
               <DialogTitle>{editingId ? "Edit" : "Add"} Beer</DialogTitle>
             </DialogHeader>

--- a/client/src/pages/ManageWinePage.tsx
+++ b/client/src/pages/ManageWinePage.tsx
@@ -203,7 +203,7 @@ export default function ManageWinePage() {
                 Add Wine
               </Button>
             </DialogTrigger>
-            <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+            <DialogContent className="max-w-2xl">
               <DialogHeader>
                 <DialogTitle>{editingId ? "Edit Wine" : "Add Wine"}</DialogTitle>
               </DialogHeader>

--- a/client/src/pages/ManageWinePage.tsx
+++ b/client/src/pages/ManageWinePage.tsx
@@ -203,7 +203,7 @@ export default function ManageWinePage() {
                 Add Wine
               </Button>
             </DialogTrigger>
-            <DialogContent className="max-w-2xl">
+            <DialogContent className="sm:max-w-2xl">
               <DialogHeader>
                 <DialogTitle>{editingId ? "Edit Wine" : "Add Wine"}</DialogTitle>
               </DialogHeader>

--- a/client/src/pages/StylePage.tsx
+++ b/client/src/pages/StylePage.tsx
@@ -104,7 +104,7 @@ export default function StylePage() {
               Add Style
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-w-md">
+          <DialogContent className="sm:max-w-md">
             <DialogHeader>
               <DialogTitle>{editingId ? "Edit" : "Add"} Beer Style</DialogTitle>
             </DialogHeader>

--- a/client/src/pages/WineManagement.tsx
+++ b/client/src/pages/WineManagement.tsx
@@ -55,14 +55,14 @@ export default function WineManagement() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white border-b border-gray-200 shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex flex-wrap justify-between items-center gap-y-2">
           <Link href="/">
             <div className="flex items-center gap-3">
               <Wine className="w-8 h-8 text-purple-600" />
               <h1 className="text-2xl font-bold text-gray-900">Wine Management</h1>
             </div>
           </Link>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-4">
             <Link href="/wine/inventory">
               <Button variant="outline" size="sm">
                 <ListChecks className="w-4 h-4 mr-1" />
@@ -76,7 +76,7 @@ export default function WineManagement() {
             </Link>
             {user && (
               <>
-                <span className="text-sm text-gray-600">Welcome, {user.name}</span>
+                <span className="hidden sm:inline text-sm text-gray-600">Welcome, {user.name}</span>
                 <Button variant="outline" size="sm" onClick={handleLogout}>
                   Logout
                 </Button>


### PR DESCRIPTION
@/tmp/claude-1000/-home-dcassel-git-dmcassel-beer-menu/8a40b18c-a0ca-431f-bf96-c081dee5690e/scratchpad/pr-body.txt